### PR TITLE
Make ApiClient and ApiClientMock extensible

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -10,28 +10,28 @@ use GuzzleHttp\Psr7\Request;
 use Symfony\Component\HttpFoundation\File\File;
 use Webmozart\Assert\Assert;
 
-final class ApiClient implements ApiClientInterface
+class ApiClient implements ApiClientInterface
 {
     /** @var string */
-    private $token;
+    protected $token;
 
     /** @var ClientInterface */
-    private $httpClient;
+    protected $httpClient;
 
     /** @var string */
-    private $baseUrl;
+    protected $baseUrl;
 
     /** @var string */
-    private $username;
+    protected $username;
 
     /** @var string */
-    private $password;
+    protected $password;
 
     /** @var string */
-    private $clientId;
+    protected $clientId;
 
     /** @var string */
-    private $secret;
+    protected $secret;
 
     public function __construct(
         ClientInterface $httpClient,
@@ -169,7 +169,7 @@ final class ApiClient implements ApiClientInterface
         return $products;
     }
 
-    private function login(): void
+    protected function login(): void
     {
         $body = json_encode(
             [
@@ -206,7 +206,7 @@ final class ApiClient implements ApiClientInterface
      * @throws GuzzleException
      * @throws \HttpException
      */
-    private function doRequestByEndpoint(string $endpoint)
+    protected function doRequestByEndpoint(string $endpoint)
     {
         return $this->doRequest($this->baseUrl . $endpoint);
     }
@@ -217,7 +217,7 @@ final class ApiClient implements ApiClientInterface
      * @throws GuzzleException
      * @throws \HttpException
      */
-    private function doRequest(string $uri)
+    protected function doRequest(string $uri)
     {
         $headers = [
             'Content-Type' => 'application/json',
@@ -238,7 +238,7 @@ final class ApiClient implements ApiClientInterface
      * @throws \HttpException
      * @throws GuzzleException
      */
-    private function getResourceOrNull(string $endpoint): ?array
+    protected function getResourceOrNull(string $endpoint): ?array
     {
         try {
             $response = $this->doRequestByEndpoint($endpoint);

--- a/tests/Integration/TestDouble/ApiClientMock.php
+++ b/tests/Integration/TestDouble/ApiClientMock.php
@@ -7,9 +7,9 @@ namespace Tests\Webgriffe\SyliusAkeneoPlugin\Integration\TestDouble;
 use Symfony\Component\HttpFoundation\File\File;
 use Webgriffe\SyliusAkeneoPlugin\ApiClientInterface;
 
-final class ApiClientMock implements ApiClientInterface
+class ApiClientMock implements ApiClientInterface
 {
-    private $productsUpdatedAt = [];
+    protected $productsUpdatedAt = [];
 
     public function findProductModel(string $code): ?array
     {
@@ -48,7 +48,7 @@ final class ApiClientMock implements ApiClientInterface
     /**
      * @return mixed|null
      */
-    private function jsonDecodeOrNull(string $filename)
+    protected function jsonDecodeOrNull(string $filename)
     {
         if (file_exists($filename)) {
             return json_decode(file_get_contents($filename), true);


### PR DESCRIPTION
@fabianaromagnoli @LucaGallinari do you agree with this?
As @fabianaromagnoli knows, in a project we have to create an AttributeOptionsImporter and having a final ApiClient force us to "fork" the ApiClient in the project.