### PR TITLE
Make ApiClient decoratable

### DIFF
--- a/src/ApiClientInterface.php
+++ b/src/ApiClientInterface.php
@@ -6,6 +6,8 @@ namespace Webgriffe\SyliusAkeneoPlugin;
 
 interface ApiClientInterface
 {
+    public function authenticatedRequest(string $uri, string $method, array $headers): array;
+
     public function findProductModel(string $code): ?array;
 
     public function findFamilyVariant(string $familyCode, string $familyVariantCode): ?array;

--- a/tests/Integration/TestDouble/ApiClientMock.php
+++ b/tests/Integration/TestDouble/ApiClientMock.php
@@ -11,6 +11,11 @@ final class ApiClientMock implements ApiClientInterface
 {
     private $productsUpdatedAt = [];
 
+    public function authenticatedRequest(string $uri, string $method, array $headers): array
+    {
+        throw new \RuntimeException('Not implemented.');
+    }
+
     public function findProductModel(string $code): ?array
     {
         return $this->jsonDecodeOrNull(__DIR__ . '/../DataFixtures/ApiClientMock/ProductModel/' . $code . '.json');


### PR DESCRIPTION
Make the ApiClient decoratable and more generic by introducing the `authenticatedRequest` method.

This will introduce a BC break.