### PR TITLE
Add product variant status resolver to product Importer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "license": "MIT",
     "require": {
         "php": "^7.3",
-
-        "sylius/sylius": "^1.8",
+        "cocur/slugify": "^4.0",
         "guzzlehttp/guzzle": "^6.5",
-        "cocur/slugify": "^4.0"
+        "sylius/sylius": "^1.8",
+        "symfony/deprecation-contracts": "^2.2"
     },
     "require-dev": {
         "ext-json": "*",

--- a/spec/Product/VariantStatusResolverSpec.php
+++ b/spec/Product/VariantStatusResolverSpec.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Webgriffe\SyliusAkeneoPlugin\Product;
+
+use PhpSpec\ObjectBehavior;
+use Webgriffe\SyliusAkeneoPlugin\Product\StatusResolverInterface;
+use Webgriffe\SyliusAkeneoPlugin\Product\VariantStatusResolver;
+
+class VariantStatusResolverSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(VariantStatusResolver::class);
+    }
+
+    function it_implements_status_resolver_interface()
+    {
+        $this->shouldHaveType(StatusResolverInterface::class);
+    }
+
+    function it_resolve_to_enabled_status_when_akeneo_product_is_enabled()
+    {
+        $this->resolve(['enabled' => true])->shouldReturn(true);
+    }
+
+    function it_resolve_to_disabled_status_when_akeneo_product_is_disabled()
+    {
+        $this->resolve(['enabled' => false])->shouldReturn(false);
+    }
+}

--- a/src/Product/Importer.php
+++ b/src/Product/Importer.php
@@ -76,7 +76,7 @@ final class Importer implements ImporterInterface
         ChannelsResolverInterface $channelsResolver,
         StatusResolverInterface $statusResolver,
         FactoryInterface $productTaxonFactory,
-        StatusResolverInterface $variantStatusResolver
+        StatusResolverInterface $variantStatusResolver = null
     ) {
         $this->productVariantFactory = $productVariantFactory;
         $this->productVariantRepository = $productVariantRepository;
@@ -90,6 +90,16 @@ final class Importer implements ImporterInterface
         $this->channelsResolver = $channelsResolver;
         $this->statusResolver = $statusResolver;
         $this->productTaxonFactory = $productTaxonFactory;
+        if (null === $variantStatusResolver) {
+            trigger_deprecation(
+                'webgriffe/sylius-akeneo-plugin',
+                '1.2',
+                'Not passing a variant status resolver to "%s" is deprecated and will be removed in %s.',
+                __CLASS__,
+                '2.0'
+            );
+            $variantStatusResolver = new VariantStatusResolver();
+        }
         $this->variantStatusResolver = $variantStatusResolver;
     }
 

--- a/src/Product/Importer.php
+++ b/src/Product/Importer.php
@@ -60,6 +60,9 @@ final class Importer implements ImporterInterface
     /** @var FactoryInterface */
     private $productTaxonFactory;
 
+    /** @var StatusResolverInterface */
+    private $variantStatusResolver;
+
     public function __construct(
         ProductVariantFactoryInterface $productVariantFactory,
         ProductVariantRepositoryInterface $productVariantRepository,
@@ -72,7 +75,8 @@ final class Importer implements ImporterInterface
         EventDispatcherInterface $eventDispatcher,
         ChannelsResolverInterface $channelsResolver,
         StatusResolverInterface $statusResolver,
-        FactoryInterface $productTaxonFactory
+        FactoryInterface $productTaxonFactory,
+        StatusResolverInterface $variantStatusResolver
     ) {
         $this->productVariantFactory = $productVariantFactory;
         $this->productVariantRepository = $productVariantRepository;
@@ -86,6 +90,7 @@ final class Importer implements ImporterInterface
         $this->channelsResolver = $channelsResolver;
         $this->statusResolver = $statusResolver;
         $this->productTaxonFactory = $productTaxonFactory;
+        $this->variantStatusResolver = $variantStatusResolver;
     }
 
     /**
@@ -119,6 +124,7 @@ final class Importer implements ImporterInterface
         $productVariant->setProduct($product);
 
         $product->setEnabled($this->statusResolver->resolve($productVariantResponse));
+        $productVariant->setEnabled($this->variantStatusResolver->resolve($productVariantResponse));
 
         foreach ($productVariantResponse['values'] as $attribute => $value) {
             $valueHandlers = $this->valueHandlersResolver->resolve($productVariant, $attribute, $value);

--- a/src/Product/VariantStatusResolver.php
+++ b/src/Product/VariantStatusResolver.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webgriffe\SyliusAkeneoPlugin\Product;
+
+final class VariantStatusResolver implements StatusResolverInterface
+{
+    public function resolve(array $akeneoProduct): bool
+    {
+        return $akeneoProduct['enabled'];
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -68,7 +68,8 @@
         <service id="Webgriffe\SyliusAkeneoPlugin\Product\ChannelsResolverInterface" alias="webgriffe_sylius_akeneo.product.channels_resolver" />
 
         <service id="webgriffe_sylius_akeneo.product.status_resolver" class="Webgriffe\SyliusAkeneoPlugin\Product\StatusResolver" />
-        <service id="Webgriffe\SyliusAkeneoPlugin\Product\StatusResolverInterface" alias="webgriffe_sylius_akeneo.product.status_resolver"/>
+
+        <service id="webgriffe_sylius_akeneo.product.variant_status_resolver" class="Webgriffe\SyliusAkeneoPlugin\Product\VariantStatusResolver" />
 
         <service id="webgriffe_sylius_akeneo.product.importer" class="Webgriffe\SyliusAkeneoPlugin\Product\Importer">
             <argument type="service" id="sylius.factory.product_variant" />
@@ -83,6 +84,7 @@
             <argument type="service" id="webgriffe_sylius_akeneo.product.channels_resolver" />
             <argument type="service" id="webgriffe_sylius_akeneo.product.status_resolver" />
             <argument type="service" id="sylius.factory.product_taxon" />
+            <argument type="service" id="webgriffe_sylius_akeneo.product.variant_status_resolver" />
         </service>
 
         <!-- Product Associations Importer -->

--- a/tests/Integration/Product/ImporterTest.php
+++ b/tests/Integration/Product/ImporterTest.php
@@ -434,6 +434,7 @@ final class ImporterTest extends KernelTestCase
 
         $product = $this->productRepository->findOneByCode('16466450');
         $this->assertFalse($product->isEnabled());
+        $this->assertFalse($product->getVariants()->first()->isEnabled());
     }
 
     /**
@@ -457,5 +458,28 @@ final class ImporterTest extends KernelTestCase
 
         $product = $this->productRepository->findOneByCode('model-braided-hat');
         $this->assertTrue($product->isEnabled());
+    }
+
+    /**
+     * @test
+     */
+    public function it_imports_disabled_variant_of_a_configurable_product_if_it_is_disabled_on_akeneo()
+    {
+        $this->fixtureLoader->load(
+            [
+                __DIR__ . '/../DataFixtures/ORM/resources/Locale/en_US.yaml',
+                __DIR__ . '/../DataFixtures/ORM/resources/Product/model-braided-hat.yaml',
+                __DIR__ . '/../DataFixtures/ORM/resources/ProductOptionValue/size_m.yaml',
+                __DIR__ . '/../DataFixtures/ORM/resources/ProductVariant/braided-hat-m.yaml',
+            ],
+            [],
+            [],
+            PurgeMode::createDeleteMode()
+        );
+
+        $this->importer->import('braided-hat-s');
+
+        $productVariant = $this->productVariantRepository->findOneByCode('braided-hat-s');
+        $this->assertFalse($productVariant->isEnabled());
     }
 }

--- a/tests/Integration/Product/ImporterTest.php
+++ b/tests/Integration/Product/ImporterTest.php
@@ -419,7 +419,7 @@ final class ImporterTest extends KernelTestCase
     /**
      * @test
      */
-    public function it_imports_disabled_product_if_it_is_disabled_on_akeneo()
+    public function it_imports_product_as_disabled_if_it_is_disabled_on_akeneo_and_has_not_a_parent_model()
     {
         $this->fixtureLoader->load(
             [
@@ -440,7 +440,7 @@ final class ImporterTest extends KernelTestCase
     /**
      * @test
      */
-    public function it_does_not_disable_product_when_importing_variant_of_a_configurable_product()
+    public function it_imports_product_as_enabled_even_if_is_disabled_on_akeneo_but_has_a_parent_model()
     {
         $this->fixtureLoader->load(
             [
@@ -463,7 +463,7 @@ final class ImporterTest extends KernelTestCase
     /**
      * @test
      */
-    public function it_imports_disabled_variant_of_a_configurable_product_if_it_is_disabled_on_akeneo()
+    public function it_imports_variant_of_a_configurable_product_as_disabled_if_it_is_disabled_on_akeneo()
     {
         $this->fixtureLoader->load(
             [


### PR DESCRIPTION
Implements #8.

A new product variant status resolver is passed to the Importer which imports the same status the product has on Akeneo. The old status resolver is still used to resolve the status on the (parent) product and still behave like before: if the product on Akeneo has a parent model the status will be always enabled otherwise the product has the same status that has on Akeneo.