### PR TITLE
Exclude missing locales during import

### DIFF
--- a/spec/ValueHandler/TranslatablePropertyValueHandlerSpec.php
+++ b/spec/ValueHandler/TranslatablePropertyValueHandlerSpec.php
@@ -157,20 +157,10 @@ class TranslatablePropertyValueHandlerSpec extends ObjectBehavior
 
     function it_skips_locales_not_specified_in_sylius(
         ProductVariantInterface $productVariant,
-        ProductInterface $product,
         ProductTranslationInterface $productTranslation,
         ProductVariantTranslationInterface $productVariantTranslation,
         PropertyAccessorInterface $propertyAccessor
     ) {
-        $productVariant->getProduct()->willReturn($product);
-        $productVariant->getTranslation('en_US')->willReturn($productVariantTranslation);
-        $productVariantTranslation->getLocale()->willReturn('en_US');
-        $productVariantTranslation->getTranslatable()->willReturn($productVariant);
-        $product->getTranslation('en_US')->shouldBeCalled()->willReturn($productTranslation);
-        $productTranslation->getLocale()->willReturn('en_US');
-        $propertyAccessor->isWritable($productTranslation, self::TRANSLATION_PROPERTY_PATH)->willReturn(true);
-        $propertyAccessor->isWritable($productVariantTranslation, self::TRANSLATION_PROPERTY_PATH)->willReturn(true);
-
         $this->handle($productVariant, self::AKENEO_ATTRIBUTE_CODE, [['locale' => 'es_ES', 'scope' => null, 'data' => 'New value']]);
 
         $propertyAccessor->setValue($productVariantTranslation, self::TRANSLATION_PROPERTY_PATH, 'New value')->shouldNotHaveBeenCalled();

--- a/spec/ValueHandler/TranslatablePropertyValueHandlerSpec.php
+++ b/spec/ValueHandler/TranslatablePropertyValueHandlerSpec.php
@@ -155,6 +155,28 @@ class TranslatablePropertyValueHandlerSpec extends ObjectBehavior
         $propertyAccessor->setValue($newProductTranslation, self::TRANSLATION_PROPERTY_PATH, 'New value')->shouldHaveBeenCalled();
     }
 
+    function it_skips_locales_not_specified_in_sylius(
+        ProductVariantInterface $productVariant,
+        ProductInterface $product,
+        ProductTranslationInterface $productTranslation,
+        ProductVariantTranslationInterface $productVariantTranslation,
+        PropertyAccessorInterface $propertyAccessor
+    ) {
+        $productVariant->getProduct()->willReturn($product);
+        $productVariant->getTranslation('en_US')->willReturn($productVariantTranslation);
+        $productVariantTranslation->getLocale()->willReturn('en_US');
+        $productVariantTranslation->getTranslatable()->willReturn($productVariant);
+        $product->getTranslation('en_US')->shouldBeCalled()->willReturn($productTranslation);
+        $productTranslation->getLocale()->willReturn('en_US');
+        $propertyAccessor->isWritable($productTranslation, self::TRANSLATION_PROPERTY_PATH)->willReturn(true);
+        $propertyAccessor->isWritable($productVariantTranslation, self::TRANSLATION_PROPERTY_PATH)->willReturn(true);
+
+        $this->handle($productVariant, self::AKENEO_ATTRIBUTE_CODE, [['locale' => 'es_ES', 'scope' => null, 'data' => 'New value']]);
+
+        $propertyAccessor->setValue($productVariantTranslation, self::TRANSLATION_PROPERTY_PATH, 'New value')->shouldNotHaveBeenCalled();
+        $propertyAccessor->setValue($productTranslation, self::TRANSLATION_PROPERTY_PATH, 'New value')->shouldNotHaveBeenCalled();
+    }
+
     function it_sets_value_on_all_product_translations_when_locale_not_specified(
         ProductVariantInterface $productVariant,
         ProductVariantTranslationInterface $englishProductVariantTranslation,

--- a/src/ValueHandler/TranslatablePropertyValueHandler.php
+++ b/src/ValueHandler/TranslatablePropertyValueHandler.php
@@ -79,6 +79,11 @@ final class TranslatablePropertyValueHandler implements ValueHandlerInterface
 
                 continue;
             }
+
+            if (!in_array($localeCode, $this->localeProvider->getDefinedLocalesCodes())) {
+                continue;
+            }
+
             $variantTranslation = $this->getOrCreateNewProductVariantTranslation($subject, $localeCode);
             $this->setValueOnProductVariantAndProductTranslation($variantTranslation, $item['data']);
         }


### PR DESCRIPTION
If Akeneo contains data in a locale that is not found in Sylius, this simply ignores all values for that locale