### PR TITLE
Fix clean up command on specifying 0 as retention number of days

### DIFF
--- a/features/cleaning_queue.feature
+++ b/features/cleaning_queue.feature
@@ -35,5 +35,5 @@ Feature: cleaning queue
     And there is an already imported item with identifier "braided-hat-s" for the "Product" importer in the Akeneo queue
     And this item has been imported 20 days ago
     When I clean the queue specifying 0 days of retention
-    Then I should be notified that 2 item has been deleted
-    And there shouldn't be any more item to clean
+    Then I should be notified that 2 items have been deleted
+    And there shouldn't be any more items to clean

--- a/features/cleaning_queue.feature
+++ b/features/cleaning_queue.feature
@@ -27,3 +27,13 @@ Feature: cleaning queue
     When I clean the queue specifying 16 days of retention
     Then I should be notified that 1 item has been deleted
     And there shouldn't be any more item to clean
+
+  @cli
+  Scenario: Cleaning the queue specifying zero as retention number of days
+    Given there is an already imported item with identifier "braided-hat-m" for the "Product" importer in the Akeneo queue
+    And this item has been imported now
+    And there is an already imported item with identifier "braided-hat-s" for the "Product" importer in the Akeneo queue
+    And this item has been imported 20 days ago
+    When I clean the queue specifying 0 days of retention
+    Then I should be notified that 2 item has been deleted
+    And there shouldn't be any more item to clean

--- a/src/Command/QueueCleanupCommand.php
+++ b/src/Command/QueueCleanupCommand.php
@@ -58,7 +58,7 @@ final class QueueCleanupCommand extends Command
         $numberOfDays = self::DEFAULT_DAYS;
         // get the number of days from user
         $numberOfDaysEntered = $input->getArgument(self::DAYS_ARGUMENT_NAME);
-        if ($numberOfDaysEntered) {
+        if ($numberOfDaysEntered !== null) {
             if (!is_string($numberOfDaysEntered) || (int) $numberOfDaysEntered < 0) {
                 $output->writeln('Sorry, the number of days entered is not valid!');
 

--- a/tests/Behat/Context/Cli/QueueCleanupCommandContext.php
+++ b/tests/Behat/Context/Cli/QueueCleanupCommandContext.php
@@ -57,7 +57,7 @@ final class QueueCleanupCommandContext implements Context
     }
 
     /**
-     * @Then /^I should be notified that (\d+) item has been deleted$/
+     * @Then /^I should be notified that (\d+) item[s]? (has|have) been deleted$/
      */
     public function iShouldBeNotifiedThatItemHasBeenDeleted(int $count)
     {
@@ -66,7 +66,7 @@ final class QueueCleanupCommandContext implements Context
     }
 
     /**
-     * @Then /^there shouldn\'t be any more item to clean$/
+     * @Then /^there shouldn\'t be any more item[s]? to clean$/
      */
     public function thereShouldntBeAnyMoreItemToClean()
     {

--- a/tests/Behat/Context/Setup/QueueContext.php
+++ b/tests/Behat/Context/Setup/QueueContext.php
@@ -83,4 +83,13 @@ final class QueueContext implements Context
         $queueItem->setImportedAt(new \DateTime("$days days ago"));
         $this->queueItemRepository->add($queueItem);
     }
+
+    /**
+     * @Given /^(this item) has been imported now$/
+     */
+    public function thisItemHasBeenImportedNow(QueueItemInterface $queueItem)
+    {
+        $queueItem->setImportedAt(new \DateTime());
+        $this->queueItemRepository->add($queueItem);
+    }
 }


### PR DESCRIPTION
These changes allow you to delete the import queue items from the current date by entering 0 as a parameter. These PR will close issue #41 .