### PR TITLE
Remove duplicated queue_item resource definition

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -209,9 +209,8 @@
     </PossiblyUndefinedMethod>
   </file>
   <file src="src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php">
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="5">
       <code>$config['api_client']</code>
-      <code>$config['resources']</code>
       <code>$config['value_handlers']['product'] ?? []</code>
       <code>$options</code>
       <code>self::$valueHandlersTypesDefinitions[$type]['arguments']</code>
@@ -397,9 +396,6 @@
       <code>$attribute</code>
       <code>$attribute</code>
     </ArgumentTypeCoercion>
-    <InvalidScalarArgument occurrences="1">
-      <code>$value</code>
-    </InvalidScalarArgument>
     <MixedArgument occurrences="4">
       <code>$attributeConfiguration['choices']</code>
       <code>$valueData['data']</code>

--- a/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
+++ b/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
@@ -19,6 +19,7 @@ use Webgriffe\SyliusAkeneoPlugin\ValueHandler\ImageValueHandler;
 use Webgriffe\SyliusAkeneoPlugin\ValueHandler\ImmutableSlugValueHandler;
 use Webgriffe\SyliusAkeneoPlugin\ValueHandler\ProductOptionValueHandler;
 use Webgriffe\SyliusAkeneoPlugin\ValueHandler\TranslatablePropertyValueHandler;
+use Webmozart\Assert\Assert;
 
 final class WebgriffeSyliusAkeneoExtension extends AbstractResourceExtension implements CompilerPassInterface
 {
@@ -102,6 +103,8 @@ final class WebgriffeSyliusAkeneoExtension extends AbstractResourceExtension imp
     {
         $config = $this->processConfiguration($this->getConfiguration([], $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+
+        Assert::isArray($config['resources']);
 
         $this->registerResources('webgriffe_sylius_akeneo', 'doctrine/orm', $config['resources'], $container);
         // The following registers plugin resources again with a different prefix. This is only for BC compatibility

--- a/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
+++ b/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
@@ -103,7 +103,7 @@ final class WebgriffeSyliusAkeneoExtension extends AbstractResourceExtension imp
         $config = $this->processConfiguration($this->getConfiguration([], $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
 
-        $this->registerResources('webgriffe_sylius_akeneo_plugin', 'doctrine/orm', $config['resources'], $container);
+        $this->registerResources('webgriffe_sylius_akeneo', 'doctrine/orm', $config['resources'], $container);
         $this->registerApiClientParameters($config['api_client'], $container);
 
         $loader->load('services.xml');

--- a/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
+++ b/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
@@ -104,6 +104,9 @@ final class WebgriffeSyliusAkeneoExtension extends AbstractResourceExtension imp
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
 
         $this->registerResources('webgriffe_sylius_akeneo', 'doctrine/orm', $config['resources'], $container);
+        // The following registers plugin resources again with a different prefix. This is only for BC compatibility
+        // and could be removed in 2.x.
+        $this->registerResources('webgriffe_sylius_akeneo_plugin', 'doctrine/orm', $config['resources'], $container);
         $this->registerApiClientParameters($config['api_client'], $container);
 
         $loader->load('services.xml');

--- a/src/Resources/config/admin_routing.yaml
+++ b/src/Resources/config/admin_routing.yaml
@@ -15,5 +15,5 @@ webgriffe_sylius_akeneo_admin_queue_item:
     type: sylius.resource
 
 webgriffe_sylius_akeneo_product_enqueue:
-    controller: webgriffe_sylius_akeneo_plugin.controller.product_enqueue_controller:enqueueAction
+    controller: webgriffe_sylius_akeneo.controller.product_enqueue_controller:enqueueAction
     path: product/{productId}/enqueue

--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -1,10 +1,3 @@
-sylius_resource:
-    resources:
-        webgriffe_sylius_akeneo.queue_item:
-            classes:
-                model: Webgriffe\SyliusAkeneoPlugin\Entity\QueueItem
-                repository: Webgriffe\SyliusAkeneoPlugin\Doctrine\ORM\QueueItemRepository
-
 sylius_grid:
     templates:
         action:

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -16,9 +16,6 @@
                 </service>
             </argument>
         </service>
-        <!-- The following alias is for backward compatibility. It could be removed in 2.x -->
-        <service id="webgriffe_sylius_akeneo_plugin.repository.cleanable_queue_item" alias="webgriffe_sylius_akeneo.repository.cleanable_queue_item" />
-
 
         <!-- Commands -->
         <service id="webgriffe_sylius_akeneo.command.consume" class="Webgriffe\SyliusAkeneoPlugin\Command\ConsumeCommand">
@@ -72,8 +69,6 @@
             <argument type="service" id="sylius.repository.product" />
             <argument type="service" id="router.default" />
         </service>
-        <!-- The following alias is for backward compatibility. It could be removed in 2.x -->
-        <service id="webgriffe_sylius_akeneo_plugin.repository.cleanable_queue_item" alias="webgriffe_sylius_akeneo.controller.product_enqueue_controller" />
 
         <service id="webgriffe_sylius_akeneo.temporary_file_manager" class="Webgriffe\SyliusAkeneoPlugin\TemporaryFilesManager">
             <argument type="service" id="filesystem" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,7 +7,7 @@
 
     <services>
 
-        <service id="webgriffe_sylius_akeneo_plugin.repository.cleanable_queue_item" class="Webgriffe\SyliusAkeneoPlugin\Doctrine\ORM\QueueItemRepository">
+        <service id="webgriffe_sylius_akeneo.repository.cleanable_queue_item" class="Webgriffe\SyliusAkeneoPlugin\Doctrine\ORM\QueueItemRepository">
             <argument type="service" id="webgriffe_sylius_akeneo.manager.queue_item" />
             <argument type="service">
                 <service class="Doctrine\ORM\Mapping\ClassMetadata" public="false" >
@@ -16,25 +16,28 @@
                 </service>
             </argument>
         </service>
+        <!-- The following alias is for backward compatibility. It could be removed in 2.x -->
+        <service id="webgriffe_sylius_akeneo_plugin.repository.cleanable_queue_item" alias="webgriffe_sylius_akeneo.repository.cleanable_queue_item" />
+
 
         <!-- Commands -->
         <service id="webgriffe_sylius_akeneo.command.consume" class="Webgriffe\SyliusAkeneoPlugin\Command\ConsumeCommand">
-            <argument type="service" id="webgriffe_sylius_akeneo_plugin.repository.queue_item" />
+            <argument type="service" id="webgriffe_sylius_akeneo.repository.queue_item" />
             <argument type="service" id="webgriffe_sylius_akeneo.importer_registry"/>
             <argument type="service" id="doctrine"/>
             <tag name="console.command" />
         </service>
 
         <service id="webgriffe_sylius_akeneo.command.enqueue" class="Webgriffe\SyliusAkeneoPlugin\Command\EnqueueCommand">
-            <argument type="service" id="webgriffe_sylius_akeneo_plugin.repository.queue_item"/>
-            <argument type="service" id="webgriffe_sylius_akeneo_plugin.factory.queue_item"/>
+            <argument type="service" id="webgriffe_sylius_akeneo.repository.queue_item"/>
+            <argument type="service" id="webgriffe_sylius_akeneo.factory.queue_item"/>
             <argument type="service" id="webgriffe_sylius_akeneo.date_time_builder"/>
             <argument type="service" id="webgriffe_sylius_akeneo.importer_registry"/>
             <tag name="console.command" />
         </service>
 
         <service id="webgriffe_sylius_akeneo.command.queue_cleanup" class="Webgriffe\SyliusAkeneoPlugin\Command\QueueCleanupCommand">
-            <argument type="service" id="webgriffe_sylius_akeneo_plugin.repository.cleanable_queue_item"/>
+            <argument type="service" id="webgriffe_sylius_akeneo.repository.cleanable_queue_item"/>
             <tag name="console.command" />
         </service>
 
@@ -63,12 +66,14 @@
         <service id="webgriffe_sylius_akeneo.slugify" class="Cocur\Slugify\Slugify" />
         <service id="Cocur\Slugify\SlugifyInterface" alias="webgriffe_sylius_akeneo.slugify" />
 
-        <service id="webgriffe_sylius_akeneo_plugin.controller.product_enqueue_controller" class="Webgriffe\SyliusAkeneoPlugin\Controller\ProductEnqueueController" >
+        <service id="webgriffe_sylius_akeneo.controller.product_enqueue_controller" class="Webgriffe\SyliusAkeneoPlugin\Controller\ProductEnqueueController" >
             <tag name="controller.service_arguments"/>
-            <argument type="service" id='webgriffe_sylius_akeneo_plugin.repository.queue_item' />
+            <argument type="service" id='webgriffe_sylius_akeneo.repository.queue_item' />
             <argument type="service" id="sylius.repository.product" />
             <argument type="service" id="router.default" />
         </service>
+        <!-- The following alias is for backward compatibility. It could be removed in 2.x -->
+        <service id="webgriffe_sylius_akeneo_plugin.repository.cleanable_queue_item" alias="webgriffe_sylius_akeneo.controller.product_enqueue_controller" />
 
         <service id="webgriffe_sylius_akeneo.temporary_file_manager" class="Webgriffe\SyliusAkeneoPlugin\TemporaryFilesManager">
             <argument type="service" id="filesystem" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -16,6 +16,8 @@
                 </service>
             </argument>
         </service>
+        <!-- The following alias is for BC compatibility and could be removed in 2.x. -->
+        <service id="webgriffe_sylius_akeneo_plugin.repository.cleanable_queue_item" alias="webgriffe_sylius_akeneo.repository.cleanable_queue_item" />
 
         <!-- Commands -->
         <service id="webgriffe_sylius_akeneo.command.consume" class="Webgriffe\SyliusAkeneoPlugin\Command\ConsumeCommand">
@@ -69,6 +71,8 @@
             <argument type="service" id="sylius.repository.product" />
             <argument type="service" id="router.default" />
         </service>
+        <!-- The following alias is for BC compatibility and could be removed in 2.x. -->
+        <service id="webgriffe_sylius_akeneo_plugin.controller.product_enqueue_controller" alias="webgriffe_sylius_akeneo.controller.product_enqueue_controller" />
 
         <service id="webgriffe_sylius_akeneo.temporary_file_manager" class="Webgriffe\SyliusAkeneoPlugin\TemporaryFilesManager">
             <argument type="service" id="filesystem" />

--- a/tests/Behat/Resources/services.xml
+++ b/tests/Behat/Resources/services.xml
@@ -5,8 +5,8 @@
         <defaults public="true" />
 
         <service id="webgriffe_sylius_akeneo.behat.context.setup.queue" class="Tests\Webgriffe\SyliusAkeneoPlugin\Behat\Context\Setup\QueueContext">
-            <argument type="service" id="webgriffe_sylius_akeneo_plugin.factory.queue_item" />
-            <argument type="service" id="webgriffe_sylius_akeneo_plugin.repository.queue_item" />
+            <argument type="service" id="webgriffe_sylius_akeneo.factory.queue_item" />
+            <argument type="service" id="webgriffe_sylius_akeneo.repository.queue_item" />
             <argument type="service" id="sylius.behat.shared_storage" />
         </service>
 
@@ -39,7 +39,7 @@
         </service>
 
         <service id="webgriffe_sylius_akeneo.behat.context.db.queue" class="Tests\Webgriffe\SyliusAkeneoPlugin\Behat\Context\Db\QueueContext">
-            <argument type="service" id="webgriffe_sylius_akeneo_plugin.repository.queue_item" />
+            <argument type="service" id="webgriffe_sylius_akeneo.repository.queue_item" />
         </service>
 
         <service id="webgriffe_sylius_akeneo.behat.context.system.filesystem" class="Tests\Webgriffe\SyliusAkeneoPlugin\Behat\Context\System\FilesystemContext">


### PR DESCRIPTION
As stated in #36 there is a duplicated queue_item resource definition. This PR removes it.
*Attention*: this PR introduce BC breaks in case someone decorated/used the old services definitions with the `_plugin` suffix in the service ID. I'd merge it anyway without creating a major release.