### PR TITLE
Importer: Add argument to event

### DIFF
--- a/src/ImporterInterface.php
+++ b/src/ImporterInterface.php
@@ -6,6 +6,8 @@ namespace Webgriffe\SyliusAkeneoPlugin;
 
 interface ImporterInterface
 {
+    public const EVENT_AKENEO_IMPORT = 'akeneo-import';
+
     /**
      * A string used to identify the Akeneo resource managed by this importer (for example: Product, Category, ecc...)
      */

--- a/src/Product/Importer.php
+++ b/src/Product/Importer.php
@@ -194,6 +194,7 @@ final class Importer implements ImporterInterface
     private function dispatchPreEvent(ResourceInterface $product, string $eventName): ResourceControllerEvent
     {
         $event = new ResourceControllerEvent($product);
+        $event->setArgument(self::EVENT_AKENEO_IMPORT, true);
         $this->eventDispatcher->dispatch(sprintf('sylius.product.pre_%s', $eventName), $event);
 
         return $event;
@@ -202,6 +203,7 @@ final class Importer implements ImporterInterface
     private function dispatchPostEvent(ResourceInterface $product, string $eventName): ResourceControllerEvent
     {
         $event = new ResourceControllerEvent($product);
+        $event->setArgument(self::EVENT_AKENEO_IMPORT, true);
         $this->eventDispatcher->dispatch(sprintf('sylius.product.post_%s', $eventName), $event);
 
         return $event;


### PR DESCRIPTION
This allows us to discern events that originated in the importer and
handle them differently from, e.g., events generated by Sylius.

I opted for an event because it's not a BC break and doesn't introduce multiple events being dispatched for the same action, which is cleaner in my opinion.

Closes #48 