### PR TITLE
Fix download file to not urlencode media code

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -144,7 +144,7 @@ final class ApiClient implements ApiClientInterface, AttributeOptionsApiClientIn
      */
     public function downloadFile(string $code): \SplFileInfo
     {
-        $endpoint = sprintf('/api/rest/v1/media-files/%s/download', urlencode($code));
+        $endpoint = sprintf('/api/rest/v1/media-files/%s/download', $code);
         Assert::string($this->accessToken);
         $headers = ['Authorization' => sprintf('Bearer %s', $this->accessToken)];
         $request = new Request('GET', $this->baseUrl . $endpoint, $headers);


### PR DESCRIPTION
In #52 the API client has been changed to urlencode also the media code in `ApiClient::downloadFile`. This seems to break the download file API call.