### PR TITLE
Print importer stack trace in very verbose mode

### DIFF
--- a/src/Command/ConsumeCommand.php
+++ b/src/Command/ConsumeCommand.php
@@ -83,6 +83,9 @@ final class ConsumeCommand extends Command
                         $t->getMessage()
                     )
                 );
+                if ($output->isVeryVerbose()) {
+                    $output->writeln((string) $t);
+                }
             }
 
             $this->queueItemRepository->add($queueItem);


### PR DESCRIPTION
This is just a small change but makes debugging problems in importer with `-vvv` more useful, especially when trying to find the root cause of nested exceptions.