### PR TITLE
Use search-after method for pagination

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -187,7 +187,7 @@ final class ApiClient implements ApiClientInterface, AttributeOptionsApiClientIn
     public function findProductsModifiedSince(\DateTime $date): array
     {
         $endpoint = sprintf(
-            '/api/rest/v1/products?search={"updated":[{"operator":">","value":"%s"}]}&limit=20&page=1',
+            '/api/rest/v1/products?search={"updated":[{"operator":">","value":"%s"}]}&pagination_type=search_after&limit=20',
             $date->format('Y-m-d H:i:s')
         );
 


### PR DESCRIPTION
Akeneo provides an [alternative pagination method](https://api.akeneo.com/documentation/pagination.html#the-search-after-method) for large data volumes.

As currently data is already fetched using links this change is very minimal but results in
a) a faster data retrieval
b) a fix for large product databases (for example 16.000) where page 501 could not be retrieved any more.

```
  Client error: … resulted in a `422 Unprocessable Entity` response:
  {"code":422,"message":"You have reached the maximum number of pages you can retrieve with the \"page\" pagination type. (truncated...)
```