### PR TITLE
Add missing service tag to reconciler command

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -42,6 +42,7 @@
 
         <service id="webgriffe_sylius_akeneo.command.reconcile" class="Webgriffe\SyliusAkeneoPlugin\Command\ReconcileCommand">
             <argument type="service" id="webgriffe_sylius_akeneo.reconciler_registry" />
+            <tag name="console.command" />
         </service>
 
         <!-- General -->


### PR DESCRIPTION
This makes the service definition equal to the other commands.

(The command wouldn't be found here.)