### PR TITLE
Allow nullable data (#82)

### DIFF
--- a/spec/ValueHandler/MetricPropertyValueHandlerSpec.php
+++ b/spec/ValueHandler/MetricPropertyValueHandlerSpec.php
@@ -114,6 +114,24 @@ class MetricPropertyValueHandlerSpec extends ObjectBehavior
         $propertyAccessor->setValue($product, self::PROPERTY_PATH, 23.0)->shouldHaveBeenCalled();
     }
 
+    function it_unset_value_if_value_is_null(
+        PropertyAccessorInterface $propertyAccessor,
+        ProductVariantInterface $productVariant,
+        UnitMeasurementValueConverterInterface $unitMeasurementValueConverter,
+        ProductInterface $product
+    ) {
+        $productVariant->getProduct()->willReturn($product);
+        $propertyAccessor->isWritable($productVariant, self::PROPERTY_PATH)->willReturn(false);
+        $propertyAccessor->isWritable($product, self::PROPERTY_PATH)->willReturn(true);
+
+        $this->handle($productVariant, self::AKENEO_ATTRIBUTE_CODE, [
+            ['locale' => null, 'scope' => null, 'data' => null]
+        ]);
+
+        $propertyAccessor->setValue($productVariant, self::PROPERTY_PATH, null)->shouldNotHaveBeenCalled();
+        $propertyAccessor->setValue($product, self::PROPERTY_PATH, null)->shouldHaveBeenCalled();
+    }
+
     function it_throws_if_provided_property_path_is_not_writeable_on_both_product_and_variant(
         PropertyAccessorInterface $propertyAccessor,
         ProductVariantInterface $productVariant,

--- a/src/ValueHandler/MetricPropertyValueHandler.php
+++ b/src/ValueHandler/MetricPropertyValueHandler.php
@@ -99,10 +99,13 @@ final class MetricPropertyValueHandler implements ValueHandlerInterface
     }
 
     /**
-     * @param array{amount: string, unit: string} $data
+     * @param null|array{amount: string, unit: string} $data
      */
-    private function getValue(array $data): float
+    private function getValue(?array $data): ?float
     {
+        if ($data === null) {
+            return null;
+        }
         return $this->unitMeasurementValueConverter->convert($data['amount'], $data['unit'], $this->akeneoUnitMeasurementCode);
     }
 }


### PR DESCRIPTION
When a metric attribute is not populated, the product importer will automatically add it by taking the attribute from the product family. and assigning it null. This throws an error as the getValue method of the MetricPropertyValueHandler is only expecting an array.
This change accepts a null value and returns it to empty the field if no longer populated.