### PR TITLE
Don't delete all images if current one is empty

### DIFF
--- a/features/importing_products_from_queue.feature
+++ b/features/importing_products_from_queue.feature
@@ -9,11 +9,11 @@ Feature: Importing products from queue
     Given the store operates on a single channel
     And the store is also available in "it_IT"
     And there is one item to import with identifier "braided-hat-m" for the "Product" importer in the Akeneo queue
-    And there is one item to import with identifier "Braided-hat-l" for the "Product" importer in the Akeneo queue
+    And there is one item to import with identifier "braided-hat-l" for the "Product" importer in the Akeneo queue
     When I import all items in queue
     Then the product "model-braided-hat" should exists with the right data
     And the product variant "braided-hat-m" of product "model-braided-hat" should exists with the right data
-    And the product variant "Braided-hat-l" of product "model-braided-hat" should exists with the right data
+    And the product variant "braided-hat-l" of product "model-braided-hat" should exists with the right data
 
   @cli
   Scenario: Keeping the queue item as not imported while importing non existent product model from queue
@@ -42,6 +42,6 @@ Feature: Importing products from queue
     Given the store operates on a single channel
     And the store is also available in "it_IT"
     And there is one item to import with identifier "braided-hat-m" for the "Product" importer in the Akeneo queue
-    And there is one item to import with identifier "Braided-hat-l" for the "Product" importer in the Akeneo queue
+    And there is one item to import with identifier "braided-hat-l" for the "Product" importer in the Akeneo queue
     When I import all items in queue
     Then there should not be any temporary file in the temporary files directory

--- a/src/ValueHandler/ImageValueHandler.php
+++ b/src/ValueHandler/ImageValueHandler.php
@@ -75,7 +75,7 @@ final class ImageValueHandler implements ValueHandlerInterface
         /** @var ProductInterface $product */
 
         if ($value[0]['data'] === null) {
-            $this->removeAlreadyExistentImages($product);
+            $this->removeAlreadyExistentVariantImages($subject, $product);
             return;
         }
 
@@ -89,7 +89,7 @@ final class ImageValueHandler implements ValueHandlerInterface
             Assert::isInstanceOf($productImage, ProductImageInterface::class);
             /** @var ProductImageInterface $productImage */
             $productImage->setType($this->syliusImageType);
-            $productImage->addProductVariant($subject);
+            $subject->addImage($productImage);
             $product->addImage($productImage);
         }
         $productImage->setFile($imageFile);
@@ -112,6 +112,25 @@ final class ImageValueHandler implements ValueHandlerInterface
     /**
      * @return ProductImageInterface[]
      */
+    private function getExistentProductVariantImages(
+        ProductVariantInterface $subject,
+        ProductInterface $product
+    ): array {
+        $images = [];
+        $existentProductImages = $this->getExistentProductImages($product);
+
+        foreach ($existentProductImages as $existentProductImage) {
+            if ($existentProductImage->hasProductVariant($subject)) {
+                $images[] = $existentProductImage;
+            }
+        }
+
+        return $images;
+    }
+
+    /**
+     * @return ProductImageInterface[]
+     */
     private function getExistentProductImages(ProductInterface $product): iterable
     {
         $existentProductImages = $this->productImageRepository->findBy(
@@ -122,11 +141,14 @@ final class ImageValueHandler implements ValueHandlerInterface
         return $existentProductImages;
     }
 
-    private function removeAlreadyExistentImages(ProductInterface $product): void
-    {
-        $alreadyExistentImages = $this->getExistentProductImages($product);
+    private function removeAlreadyExistentVariantImages(
+        ProductVariantInterface $subject,
+        ProductInterface $product
+    ): void {
+        $alreadyExistentImages = $this->getExistentProductVariantImages($subject, $product);
         foreach ($alreadyExistentImages as $alreadyExistentImage) {
             $product->removeImage($alreadyExistentImage);
+            $subject->removeImage($alreadyExistentImage);
         }
     }
 }

--- a/tests/Integration/DataFixtures/ApiClientMock/Product/braided-hat-l.json
+++ b/tests/Integration/DataFixtures/ApiClientMock/Product/braided-hat-l.json
@@ -1,5 +1,5 @@
 {
-    "identifier": "Braided-hat-l",
+    "identifier": "braided-hat-l",
     "enabled": true,
     "family": "accessories",
     "categories": [

--- a/tests/Integration/DataFixtures/ORM/resources/Product/model-braided-hat-with-variation-image.yaml
+++ b/tests/Integration/DataFixtures/ORM/resources/Product/model-braided-hat-with-variation-image.yaml
@@ -62,5 +62,7 @@ Sylius\Component\Product\Model\ProductAttributeValue:
 Sylius\Component\Core\Model\ProductImage:
     model-braided-hat_variation_image:
         owner: '@model-braided-hat'
+        productVariants:
+          - '@braided-hat-m'
         type: variation_image
         path: path/to/file.jpg

--- a/tests/Integration/DataFixtures/ORM/resources/ProductOptionValue/size_l.yaml
+++ b/tests/Integration/DataFixtures/ORM/resources/ProductOptionValue/size_l.yaml
@@ -2,13 +2,14 @@ Sylius\Component\Product\Model\ProductOptionValue:
   size_l:
     option: "@size"
     code: "size_l"
+    translations:
+      - "@size_l_en_US"
+      - "@size_l_it_IT"
 
 Sylius\Component\Product\Model\ProductOptionValueTranslation:
   size_l_en_US:
-    translatable: "@size_l"
     locale: "en_US"
-    value: "L"
+    value: "Large"
   size_l_it_IT:
-    translatable: "@size_l"
     locale: "it_IT"
     value: "L"

--- a/tests/Integration/DataFixtures/ORM/resources/ProductVariant/braided-hat-l.yaml
+++ b/tests/Integration/DataFixtures/ORM/resources/ProductVariant/braided-hat-l.yaml
@@ -1,0 +1,6 @@
+Sylius\Component\Core\Model\ProductVariant:
+  braided-hat-l:
+    code: 'braided-hat-l'
+    product: '@model-braided-hat'
+    optionValues:
+      - '@size_l'

--- a/tests/Integration/Product/ImporterTest.php
+++ b/tests/Integration/Product/ImporterTest.php
@@ -367,7 +367,7 @@ final class ImporterTest extends KernelTestCase
         );
 
         $this->importer->import('braided-hat-m');
-        $this->importer->import('Braided-hat-l');
+        $this->importer->import('braided-hat-l');
 
         /** @var ProductVariantInterface[] $allVariants */
         $allVariants = $this->productVariantRepository->findAll();
@@ -570,7 +570,9 @@ final class ImporterTest extends KernelTestCase
                 __DIR__ . '/../DataFixtures/ORM/resources/Locale/it_IT.yaml',
                 __DIR__ . '/../DataFixtures/ORM/resources/Product/model-braided-hat-with-variation-image.yaml',
                 __DIR__ . '/../DataFixtures/ORM/resources/ProductOptionValue/size_m.yaml',
+                __DIR__ . '/../DataFixtures/ORM/resources/ProductOptionValue/size_l.yaml',
                 __DIR__ . '/../DataFixtures/ORM/resources/ProductVariant/braided-hat-m.yaml',
+                __DIR__ . '/../DataFixtures/ORM/resources/ProductVariant/braided-hat-l.yaml',
             ],
             [],
             [],
@@ -581,6 +583,32 @@ final class ImporterTest extends KernelTestCase
 
         $product = $this->productRepository->findOneByCode('model-braided-hat');
         $this->assertCount(1, $product->getImages());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_remove_product_images_of_other_variants_removed_on_akeneo()
+    {
+        $this->fixtureLoader->load(
+            [
+                __DIR__ . '/../DataFixtures/ORM/resources/Locale/en_US.yaml',
+                __DIR__ . '/../DataFixtures/ORM/resources/Locale/it_IT.yaml',
+                __DIR__ . '/../DataFixtures/ORM/resources/Product/model-braided-hat-with-variation-image.yaml',
+                __DIR__ . '/../DataFixtures/ORM/resources/ProductOptionValue/size_m.yaml',
+                __DIR__ . '/../DataFixtures/ORM/resources/ProductOptionValue/size_l.yaml',
+                __DIR__ . '/../DataFixtures/ORM/resources/ProductVariant/braided-hat-m.yaml',
+                __DIR__ . '/../DataFixtures/ORM/resources/ProductVariant/braided-hat-l.yaml',
+            ],
+            [],
+            [],
+            PurgeMode::createDeleteMode()
+        );
+
+        $this->importer->import('braided-hat-l');
+
+        $product = $this->productRepository->findOneByCode('model-braided-hat');
+        $this->assertCount(2, $product->getImages());
     }
 
     /**


### PR DESCRIPTION
Importing more than one variant will cause all images of the current type to be deleted if the current image is null / has been removed.

This filters all images of a type for the current variant.