### PR TITLE
Add a handler for original pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,21 @@ webgriffe_sylius_akeneo:
 
 In the `akeneo_attribute_code` option you have to set the code of the **Akeneo price attribute** where you store your products prices. Then they will be imported into Sylius for channels whose base currency is the same as the price currency on Akeneo.
 
+There's also a handler managing the "original price" field:
+
+```yaml
+# config/packages/webgriffe_sylius_akeneo_plugin.yaml
+webgriffe_sylius_akeneo:
+  # ...
+  value_handlers:
+    product:
+      # ...
+      price:
+        type: 'channel_original_pricing'
+        options:
+          akeneo_attribute_code: 'original_price'      
+```
+
 ### Importing product metrical properties
 
 **NB. This feature is only available from Akeneo version 5**

--- a/spec/ValueHandler/ChannelOriginalPricingValueHandlerSpec.php
+++ b/spec/ValueHandler/ChannelOriginalPricingValueHandlerSpec.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Webgriffe\SyliusAkeneoPlugin\ValueHandler;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ChannelPricingInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Currency\Model\CurrencyInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Webgriffe\SyliusAkeneoPlugin\ValueHandler\ChannelOriginalPricingValueHandler;
+use Webgriffe\SyliusAkeneoPlugin\ValueHandlerInterface;
+
+class ChannelOriginalPricingValueHandlerSpec extends ObjectBehavior
+{
+    private const AKENEO_ATTRIBUTE = 'akeneo_attribute';
+
+    private const ITALY_CHANNEL_CODE = 'ITALY';
+
+    private const US_CHANNEL_CODE = 'US';
+
+    function let(
+        FactoryInterface $channelPricingFactory,
+        ChannelRepositoryInterface $channelRepository,
+        CurrencyInterface $eurCurrency,
+        ChannelInterface $italyChannel,
+        CurrencyInterface $usdCurrency,
+        ChannelInterface $usChannel,
+        RepositoryInterface $currencyRepository
+    ) {
+        $channelRepository
+            ->findBy(['baseCurrency' => $eurCurrency])
+            ->willReturn(new ArrayCollection([$italyChannel->getWrappedObject()]));
+        $channelRepository
+            ->findBy(['baseCurrency' => $usdCurrency])
+            ->willReturn(new ArrayCollection([$usChannel->getWrappedObject()]));
+        $channelRepository
+            ->findAll()
+            ->willReturn(new ArrayCollection([
+                $italyChannel->getWrappedObject(),
+                $usChannel->getWrappedObject(),
+            ]));
+        $italyChannel->getCode()->willReturn(self::ITALY_CHANNEL_CODE);
+        $usChannel->getCode()->willReturn(self::US_CHANNEL_CODE);
+
+        $this->beConstructedWith(
+            $channelPricingFactory,
+            $channelRepository,
+            $currencyRepository,
+            self::AKENEO_ATTRIBUTE
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ChannelOriginalPricingValueHandler::class);
+    }
+
+    function it_implements_value_handler_interface()
+    {
+        $this->shouldHaveType(ValueHandlerInterface::class);
+    }
+
+    function it_supports_product_variant_as_subject(ProductVariantInterface $productVariant)
+    {
+        $this->supports($productVariant, self::AKENEO_ATTRIBUTE, [])->shouldReturn(true);
+    }
+
+    function it_does_not_support_other_type_of_subject()
+    {
+        $this->supports(new \stdClass(), self::AKENEO_ATTRIBUTE, [])->shouldReturn(false);
+    }
+
+    function it_supports_provided_akeneo_attribute(ProductVariantInterface $productVariant)
+    {
+        $this->supports($productVariant, self::AKENEO_ATTRIBUTE, [])->shouldReturn(true);
+    }
+
+    function it_does_not_support_any_other_akeneo_attribute(ProductVariantInterface $productVariant)
+    {
+        $this->supports($productVariant, 'other_attribute', [])->shouldReturn(false);
+    }
+
+    function it_throws_exception_during_handle_when_subject_is_not_product_variant()
+    {
+        $this
+            ->shouldThrow(
+                new \InvalidArgumentException(
+                    sprintf(
+                        'This channel pricing value handler only supports instances of %s, %s given.',
+                        ProductVariantInterface::class,
+                        \stdClass::class
+                    )
+                )
+            )
+            ->during('handle', [new \stdClass(), self::AKENEO_ATTRIBUTE, []]);
+    }
+
+    function it_does_nothing_when_currency_does_not_exists(
+        ProductVariantInterface $productVariant,
+        FactoryInterface $channelPricingFactory,
+        RepositoryInterface $currencyRepository
+    ) {
+        $value = [
+            [
+                'locale' => null,
+                'scope' => null,
+                'data' => [
+                    [
+                        'amount' => '29.99',
+                        'currency' => 'EUR',
+                    ],
+                    [
+                        'amount' => '31.99',
+                        'currency' => 'USD',
+                    ],
+                ],
+            ],
+        ];
+        /** @noinspection PhpParamsInspection */
+        $currencyRepository->findOneBy(Argument::any())->willReturn(null);
+
+        $this->handle($productVariant, self::AKENEO_ATTRIBUTE, $value);
+
+        $channelPricingFactory->createNew()->shouldNotHaveBeenCalled();
+    }
+
+    function it_creates_new_original_channel_prices_for_the_matching_currency_channels(
+        ProductVariantInterface $productVariant,
+        ChannelPricingInterface $italianChannelPricing,
+        ChannelPricingInterface $usChannelPricing,
+        FactoryInterface $channelPricingFactory,
+        CurrencyInterface $eurCurrency,
+        CurrencyInterface $usdCurrency,
+        RepositoryInterface $currencyRepository
+    ) {
+        $value = [
+            [
+                'locale' => null,
+                'scope' => null,
+                'data' => [
+                    [
+                        'amount' => '29.99',
+                        'currency' => 'EUR',
+                    ],
+                    [
+                        'amount' => '31.99',
+                        'currency' => 'USD',
+                    ],
+                ],
+            ],
+        ];
+        $currencyRepository->findOneBy(['code' => 'EUR'])->willReturn($eurCurrency);
+        $currencyRepository->findOneBy(['code' => 'USD'])->willReturn($usdCurrency);
+        $channelPricingFactory->createNew()->willReturn($italianChannelPricing, $usChannelPricing);
+        /** @noinspection PhpParamsInspection */
+        $productVariant->getChannelPricingForChannel(Argument::any())->willReturn(null);
+
+        $this->handle($productVariant, self::AKENEO_ATTRIBUTE, $value);
+
+        $channelPricingFactory->createNew()->shouldHaveBeenCalledTimes(2);
+        $productVariant->addChannelPricing($italianChannelPricing)->shouldHaveBeenCalled();
+        $productVariant->addChannelPricing($usChannelPricing)->shouldHaveBeenCalled();
+        $italianChannelPricing->setOriginalPrice(2999)->shouldHaveBeenCalled();
+        $italianChannelPricing->setChannelCode(self::ITALY_CHANNEL_CODE)->shouldHaveBeenCalled();
+        $usChannelPricing->setOriginalPrice(3199)->shouldHaveBeenCalled();
+        $usChannelPricing->setChannelCode(self::US_CHANNEL_CODE)->shouldHaveBeenCalled();
+    }
+
+    function it_updates_existent_original_channel_prices_for_the_matching_currency_channels(
+        ProductVariantInterface $productVariant,
+        ChannelPricingInterface $italianChannelPricing,
+        ChannelPricingInterface $usChannelPricing,
+        FactoryInterface $channelPricingFactory,
+        CurrencyInterface $eurCurrency,
+        CurrencyInterface $usdCurrency,
+        ChannelInterface $italyChannel,
+        ChannelInterface $usChannel,
+        RepositoryInterface $currencyRepository
+    ) {
+        $value = [
+            [
+                'locale' => null,
+                'scope' => null,
+                'data' => [
+                    [
+                        'amount' => '29.99',
+                        'currency' => 'EUR',
+                    ],
+                    [
+                        'amount' => '31.99',
+                        'currency' => 'USD',
+                    ],
+                ],
+            ],
+        ];
+        $currencyRepository->findOneBy(['code' => 'EUR'])->willReturn($eurCurrency);
+        $currencyRepository->findOneBy(['code' => 'USD'])->willReturn($usdCurrency);
+        $productVariant->getChannelPricingForChannel($italyChannel)->willReturn($italianChannelPricing);
+        $productVariant->getChannelPricingForChannel($usChannel)->willReturn($usChannelPricing);
+
+        $this->handle($productVariant, self::AKENEO_ATTRIBUTE, $value);
+
+        $channelPricingFactory->createNew()->shouldNotHaveBeenCalled();
+        $italianChannelPricing->setOriginalPrice(2999)->shouldHaveBeenCalled();
+        /** @noinspection PhpStrictTypeCheckingInspection */
+        $italianChannelPricing->setChannelCode(Argument::type('string'))->shouldNotHaveBeenCalled();
+        $usChannelPricing->setOriginalPrice(3199)->shouldHaveBeenCalled();
+        /** @noinspection PhpStrictTypeCheckingInspection */
+        $usChannelPricing->setChannelCode(Argument::type('string'))->shouldNotHaveBeenCalled();
+    }
+
+    function it_removes_existent_original_channel_prices_for_the_matching_currency_channels(
+        ProductVariantInterface $productVariant,
+        ChannelPricingInterface $italianChannelPricing,
+        ChannelPricingInterface $usChannelPricing,
+        FactoryInterface $channelPricingFactory,
+        CurrencyInterface $eurCurrency,
+        CurrencyInterface $usdCurrency,
+        ChannelInterface $italyChannel,
+        ChannelInterface $usChannel,
+        RepositoryInterface $currencyRepository
+    ) {
+        $value = [
+            [
+                'locale' => null,
+                'scope' => null,
+                'data' => null,
+            ],
+        ];
+        $currencyRepository->findOneBy(['code' => 'EUR'])->willReturn($eurCurrency);
+        $currencyRepository->findOneBy(['code' => 'USD'])->willReturn($usdCurrency);
+        $productVariant->getChannelPricingForChannel($italyChannel)->willReturn($italianChannelPricing);
+        $productVariant->getChannelPricingForChannel($usChannel)->willReturn($usChannelPricing);
+
+        $this->handle($productVariant, self::AKENEO_ATTRIBUTE, $value);
+
+        $channelPricingFactory->createNew()->shouldNotHaveBeenCalled();
+        $italianChannelPricing->setOriginalPrice(null)->shouldHaveBeenCalled();
+        /** @noinspection PhpStrictTypeCheckingInspection */
+        $italianChannelPricing->setChannelCode(Argument::type('string'))->shouldNotHaveBeenCalled();
+        $usChannelPricing->setOriginalPrice(null)->shouldHaveBeenCalled();
+        /** @noinspection PhpStrictTypeCheckingInspection */
+        $usChannelPricing->setChannelCode(Argument::type('string'))->shouldNotHaveBeenCalled();
+    }
+}

--- a/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
+++ b/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Webgriffe\SyliusAkeneoPlugin\ValueHandler\AttributeValueHandler;
+use Webgriffe\SyliusAkeneoPlugin\ValueHandler\ChannelOriginalPricingValueHandler;
 use Webgriffe\SyliusAkeneoPlugin\ValueHandler\ChannelPricingValueHandler;
 use Webgriffe\SyliusAkeneoPlugin\ValueHandler\FileAttributeValueHandler;
 use Webgriffe\SyliusAkeneoPlugin\ValueHandler\GenericPropertyValueHandler;
@@ -106,6 +107,14 @@ final class WebgriffeSyliusAkeneoExtension extends AbstractResourceExtension imp
     private static $valueHandlersTypesDefinitionsPrivate = [
         'channel_pricing' => [
             'class' => ChannelPricingValueHandler::class,
+            'arguments' => [
+                'sylius.factory.channel_pricing',
+                'sylius.repository.channel',
+                'sylius.repository.currency',
+            ],
+        ],
+        'channel_original_pricing' => [
+            'class' => ChannelOriginalPricingValueHandler::class,
             'arguments' => [
                 'sylius.factory.channel_pricing',
                 'sylius.repository.channel',

--- a/src/ValueHandler/AbstractChannelPricingValueHandler.php
+++ b/src/ValueHandler/AbstractChannelPricingValueHandler.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webgriffe\SyliusAkeneoPlugin\ValueHandler;
+
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ChannelPricingInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Currency\Model\CurrencyInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Webgriffe\SyliusAkeneoPlugin\ValueHandlerInterface;
+use Webmozart\Assert\Assert;
+
+abstract class AbstractChannelPricingValueHandler implements ValueHandlerInterface
+{
+    /** @var FactoryInterface */
+    protected $channelPricingFactory;
+
+    /** @var ChannelRepositoryInterface */
+    protected $channelRepository;
+
+    /** @var RepositoryInterface */
+    protected $currencyRepository;
+
+    /** @var string */
+    protected $akeneoAttribute;
+
+    public function __construct(
+        FactoryInterface $channelPricingFactory,
+        ChannelRepositoryInterface $channelRepository,
+        RepositoryInterface $currencyRepository,
+        string $akeneoAttribute
+    ) {
+        $this->channelPricingFactory = $channelPricingFactory;
+        $this->channelRepository = $channelRepository;
+        $this->currencyRepository = $currencyRepository;
+        $this->akeneoAttribute = $akeneoAttribute;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($subject, string $attribute, array $value): bool
+    {
+        return $subject instanceof ProductVariantInterface && $attribute === $this->akeneoAttribute;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle($subject, string $attribute, array $value): void
+    {
+        if (!$subject instanceof ProductVariantInterface) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'This channel pricing value handler only supports instances of %s, %s given.',
+                    ProductVariantInterface::class,
+                    is_object($subject) ? get_class($subject) : gettype($subject)
+                )
+            );
+        }
+
+        /** @var array<array-key, array{currency: string, amount: float}> $currenciesPrices */
+        $currenciesPrices = $value[0]['data'] ?? [];
+        $this->setPrices($subject, $currenciesPrices);
+    }
+
+    /**
+     * @param array<array-key, array{currency: string, amount: float}> $currenciesPrices
+     */
+    protected function setPrices(ProductVariantInterface $variant, array $currenciesPrices): void
+    {
+        foreach ($currenciesPrices as $currencyPrice) {
+            $currencyCode = $currencyPrice['currency'];
+            $price = $currencyPrice['amount'];
+            /** @var CurrencyInterface|null $currency */
+            $currency = $this->currencyRepository->findOneBy(['code' => $currencyCode]);
+            if ($currency === null) {
+                continue;
+            }
+
+            /** @var ChannelInterface[] $channels */
+            $channels = $this->channelRepository->findBy(['baseCurrency' => $currency]);
+            foreach ($channels as $channel) {
+                $isNewChannelPricing = false;
+                $channelPricing = $variant->getChannelPricingForChannel($channel);
+                if ($channelPricing === null) {
+                    $isNewChannelPricing = true;
+                    /** @var ChannelPricingInterface $channelPricing */
+                    $channelPricing = $this->channelPricingFactory->createNew();
+                    $channelPricing->setChannelCode($channel->getCode());
+                }
+
+                $this->setPrice($channelPricing, (int) round($price * 100));
+
+                if ($isNewChannelPricing) {
+                    $variant->addChannelPricing($channelPricing);
+                }
+            }
+        }
+    }
+
+    abstract protected function setPrice(ChannelPricingInterface $channelPricing, int $price): void;
+}

--- a/src/ValueHandler/ChannelOriginalPricingValueHandler.php
+++ b/src/ValueHandler/ChannelOriginalPricingValueHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webgriffe\SyliusAkeneoPlugin\ValueHandler;
+
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ChannelPricingInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+final class ChannelOriginalPricingValueHandler extends AbstractChannelPricingValueHandler
+{
+    protected function setPrice(ChannelPricingInterface $channelPricing, int $price): void
+    {
+        $channelPricing->setOriginalPrice($price);
+    }
+
+    protected function setPrices(ProductVariantInterface $variant, array $currenciesPrices): void
+    {
+        if (empty($currenciesPrices)) {
+            $this->unsetAll($variant);
+
+        } else {
+            parent::setPrices($variant, $currenciesPrices);
+        }
+    }
+
+    private function unsetAll(ProductVariantInterface $variant): void
+    {
+        /** @var ChannelInterface[] $channels */
+        $channels = $this->channelRepository->findAll();
+
+        foreach ($channels as $channel) {
+            $channelPricing = $variant->getChannelPricingForChannel($channel);
+
+            if ($channelPricing) {
+                $channelPricing->setOriginalPrice(null);
+            }
+        }
+    }
+}

--- a/src/ValueHandler/ChannelPricingValueHandler.php
+++ b/src/ValueHandler/ChannelPricingValueHandler.php
@@ -4,92 +4,12 @@ declare(strict_types=1);
 
 namespace Webgriffe\SyliusAkeneoPlugin\ValueHandler;
 
-use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
-use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
-use Sylius\Component\Core\Model\ProductVariantInterface;
-use Sylius\Component\Currency\Model\CurrencyInterface;
-use Sylius\Component\Resource\Factory\FactoryInterface;
-use Sylius\Component\Resource\Repository\RepositoryInterface;
-use Webgriffe\SyliusAkeneoPlugin\ValueHandlerInterface;
-use Webmozart\Assert\Assert;
 
-final class ChannelPricingValueHandler implements ValueHandlerInterface
+final class ChannelPricingValueHandler extends AbstractChannelPricingValueHandler
 {
-    /** @var FactoryInterface */
-    private $channelPricingFactory;
-
-    /** @var ChannelRepositoryInterface */
-    private $channelRepository;
-
-    /** @var RepositoryInterface */
-    private $currencyRepository;
-
-    /** @var string */
-    private $akeneoAttribute;
-
-    public function __construct(
-        FactoryInterface $channelPricingFactory,
-        ChannelRepositoryInterface $channelRepository,
-        RepositoryInterface $currencyRepository,
-        string $akeneoAttribute
-    ) {
-        $this->channelPricingFactory = $channelPricingFactory;
-        $this->channelRepository = $channelRepository;
-        $this->currencyRepository = $currencyRepository;
-        $this->akeneoAttribute = $akeneoAttribute;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supports($subject, string $attribute, array $value): bool
+    protected function setPrice(ChannelPricingInterface $channelPricing, int $price): void
     {
-        return $subject instanceof ProductVariantInterface && $attribute === $this->akeneoAttribute;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function handle($subject, string $attribute, array $value): void
-    {
-        if (!$subject instanceof ProductVariantInterface) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    'This channel pricing value handler only supports instances of %s, %s given.',
-                    ProductVariantInterface::class,
-                    is_object($subject) ? get_class($subject) : gettype($subject)
-                )
-            );
-        }
-
-        /** @var array<array-key, array{currency: string, amount: float}> $currenciesPrices */
-        $currenciesPrices = $value[0]['data'] ?? [];
-        foreach ($currenciesPrices as $currencyPrice) {
-            $currencyCode = $currencyPrice['currency'];
-            $price = $currencyPrice['amount'];
-            /** @var CurrencyInterface|null $currency */
-            $currency = $this->currencyRepository->findOneBy(['code' => $currencyCode]);
-            if ($currency === null) {
-                continue;
-            }
-
-            /** @var ChannelInterface[] $channels */
-            $channels = $this->channelRepository->findBy(['baseCurrency' => $currency]);
-            foreach ($channels as $channel) {
-                $isNewChannelPricing = false;
-                $channelPricing = $subject->getChannelPricingForChannel($channel);
-                if ($channelPricing === null) {
-                    $isNewChannelPricing = true;
-                    /** @var ChannelPricingInterface $channelPricing */
-                    $channelPricing = $this->channelPricingFactory->createNew();
-                    $channelPricing->setChannelCode($channel->getCode());
-                }
-                $channelPricing->setPrice((int) round($price * 100));
-                if ($isNewChannelPricing) {
-                    $subject->addChannelPricing($channelPricing);
-                }
-            }
-        }
+        $channelPricing->setPrice($price);
     }
 }


### PR DESCRIPTION
Hey guys!

Our client now wants to handle original pricing in Akeneo as well.

I figured because the rest of that logic is 100 identical I'd just split that logic at the setter and keep both fields' handling in separated classes.

What do you think?

(The spec file is just a copy/paste job, hope that's OK.)