### PR TITLE
Format metrical amount number

### DIFF
--- a/spec/Converter/ValueConverterSpec.php
+++ b/spec/Converter/ValueConverterSpec.php
@@ -84,7 +84,7 @@ class ValueConverterSpec extends ObjectBehavior
         )->during('convert', [
             $textAttribute,
             [
-                'amount' => 23,
+                'amount' => 23.0000,
                 'key' => 'value',
             ],
             'it',
@@ -97,7 +97,7 @@ class ValueConverterSpec extends ObjectBehavior
         $this->convert(
             $textAttribute,
             [
-                'amount' => 23,
+                'amount' => 23.0000,
                 'unit' => 'INCH',
             ],
             'it'
@@ -112,7 +112,7 @@ class ValueConverterSpec extends ObjectBehavior
         $this->convert(
             $textAttribute,
             [
-                'amount' => 23,
+                'amount' => 23.0000,
                 'unit' => 'INCH',
             ],
             'it'

--- a/src/Converter/ValueConverter.php
+++ b/src/Converter/ValueConverter.php
@@ -33,7 +33,7 @@ final class ValueConverter implements ValueConverterInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function convert(AttributeInterface $attribute, $value, string $localeCode)
     {
@@ -43,16 +43,16 @@ final class ValueConverter implements ValueConverterInterface
                 if (!array_key_exists('amount', $value)) {
                     throw new \LogicException('Amount key not found');
                 }
-                $amount = number_format((float) ($value['amount']));
+                $floatAmount = (float) ($value['amount']);
                 if (!array_key_exists('unit', $value)) {
                     throw new \LogicException('Unit key not found');
                 }
                 $unit = (string) $value['unit'];
                 if ($this->translator === null) {
-                    return $amount . ' ' . $unit;
+                    return $floatAmount . ' ' . $unit;
                 }
 
-                return $this->translator->trans('webgriffe_sylius_akeneo.ui.metric_amount_unit', ['unit' => $unit, 'amount' => $amount], null, $localeCode);
+                return $this->translator->trans('webgriffe_sylius_akeneo.ui.metric_amount_unit', ['unit' => $unit, 'amount' => $floatAmount], null, $localeCode);
             }
 
             return $value;

--- a/src/Converter/ValueConverter.php
+++ b/src/Converter/ValueConverter.php
@@ -43,7 +43,7 @@ final class ValueConverter implements ValueConverterInterface
                 if (!array_key_exists('amount', $value)) {
                     throw new \LogicException('Amount key not found');
                 }
-                $amount = (string) $value['amount'];
+                $amount = number_format((float) ($value['amount']));
                 if (!array_key_exists('unit', $value)) {
                     throw new \LogicException('Unit key not found');
                 }

--- a/src/Resources/translations/messages+intl-icu.en.yaml
+++ b/src/Resources/translations/messages+intl-icu.en.yaml
@@ -2,149 +2,149 @@ webgriffe_sylius_akeneo:
   ui:
     metric_amount_unit: >-
       {unit, select,
-          SQUARE_MILLIMETER {{amount} mm²}
-          SQUARE_CENTIMETER {{amount} cm²}
-          SQUARE_DECIMETER {{amount} dm²}
-          SQUARE_METER {{amount} m²}
-          CENTIARE {{amount} ca}
-          SQUARE_DEKAMETER {{amount} dam²}
-          SQUARE_MILLIMETER {{amount} mm²}
-          ARE {{amount} a}
-          SQUARE_HECTOMETER {{amount} hm²}
-          HECTARE {{amount} ha}
-          SQUARE_KILOMETER {{amount} km²}
-          SQUARE_MIL {{amount} sq mil}
-          SQUARE_INCH {{amount} in²}
-          SQUARE_FOOT {{amount} ft²}
-          SQUARE_YARD {{amount} yd²}
-          ARPENT {{amount} arpent}
-          ACRE {{amount} a}
-          SQUARE_FURLONG {{amount} fur²}
-          SQUARE_MILE {{amount} mi²}
-          BIT {{amount} b}
-          BYTE {{amount} B}
-          KILOBYTE {{amount} kB}
-          MEGABYTE {{amount} MB}
-          GIGABYTE {{amount} GB}
-          TERABYTE {{amount} TB}
-          DECIBEL {{amount} dB}
-          HERTZ {{amount} Hz}
-          KILOHERTZ {{amount} kHz}
-          MEGAHERTZ {{amount} MHz}
-          GIGAHERTZ {{amount} GHz}
-          TERAHERTZ {{amount} THz}
-          MILLIMETER {{amount} mm}
-          CENTIMETER {{amount} cm}
-          DECIMETER {{amount} dm}
-          METER {{amount} m}
-          DEKAMETER {{amount} dam}
-          HECTOMETER {{amount} hm}
-          KILOMETER {{amount} km}
-          MIL {{amount} mil}
-          INCH {{amount} in}
-          FEET {{amount} ft}
-          YARD {{amount} yd}
-          CHAIN {{amount} ch}
-          FURLONG {{amount} fur}
-          MILE {{amount} mi}
-          WATT {{amount} W}
-          KILOWATT {{amount} kW}
-          MEGAWATT {{amount} MW}
-          GIGAWATT {{amount} GW}
-          TERAWATT {{amount} TW}
-          MILLIVOLT {{amount} mV}
-          CENTIVOLT {{amount} cV}
-          DECIVOLT {{amount} dV}
-          VOLT {{amount} V}
-          DEKAVOLT {{amount} daV}
-          HECTOVOLT {{amount} hV}
-          KILOVOLT {{amount} kV}
-          MILLIAMPERE {{amount} mA}
-          CENTIAMPERE {{amount} cA}
-          DECIAMPERE {{amount} dA}
-          AMPERE {{amount} A}
-          DEKAMPERE {{amount} daA}
-          HECTOAMPERE {{amount} hA}
-          KILOAMPERE {{amount} kA}
-          MILLIOHM {{amount} mΩ}
-          CENTIOHM {{amount} cΩ}
-          DECIOHM {{amount} dΩ}
-          OHM {{amount} Ω}
-          DEKAOHM {{amount} daΩ}
-          HECTOHM {{amount} hΩ}
-          KILOHM {{amount} kΩ}
-          MEGOHM {{amount} MΩ}
-          METER_PER_SECOND {{amount} m/s}
-          METER_PER_MINUTE {{amount} m/mn}
-          METER_PER_HOUR {{amount} m/h}
-          KILOMETER_PER_HOUR {{amount} km/h}
-          FOOT_PER_SECOND {{amount} ft/s}
-          FOOT_PER_HOUR {{amount} ft/h}
-          YARD_PER_HOUR {{amount} yd/h}
-          MILE_PER_HOUR {{amount} mi/h}
-          MILLIAMPEREHOUR {{amount} mAh}
-          AMPEREHOUR {{amount} Ah}
-          MILLICOULOMB {{amount} mC}
-          CENTICOULOMB {{amount} cC}
-          DECICOULOMB {{amount} dC}
-          COULOMB {{amount} C}
-          DEKACOULOMB {{amount} daC}
-          HECTOCOULOMB {{amount} hC}
-          KILOCOULOMB {{amount} kC}
-          MILLISECOND {{amount} ms}
-          SECOND {{amount} s}
-          MINUTE {{amount} m}
-          HOUR {{amount} h}
-          DAY {{amount} d}
-          WEEK {{amount} week}
-          MONTH {{amount} month}
-          YEAR {{amount} year}
-          CELSIUS {{amount}°C}
-          FAHRENHEIT {{amount}°F}
-          KELVIN {{amount}°K}
-          RANKINE {{amount}°R}
-          REAUMUR {{amount}°r}
-          CUBIC_MILLIMETER {{amount} mm³}
-          CUBIC_CENTIMETER {{amount} cm³}
-          MILLILITER {{amount} ml}
-          CENTILITER {{amount} cl}
-          DECILITER {{amount} dl}
-          CUBIC_DECIMETER {{amount} dm³}
-          LITER {{amount} l}
-          CUBIC_METER {{amount} m³}
-          OUNCE {{amount} oz}
-          PINT {{amount} pt}
-          BARREL {{amount} bbl}
-          GALLON {{amount} gal}
-          CUBIC_FOOT {{amount} ft³}
-          CUBIC_INCH {{amount} in³}
-          CUBIC_YARD {{amount} yd³}
-          MILLIGRAM {{amount} mg}
-          GRAM {{amount} g}
-          KILOGRAM {{amount} kg}
-          TON {{amount} t}
-          GRAIN {{amount} gr}
-          DENIER {{amount} denier}
-          ONCE {{amount} once}
-          MARC {{amount} marc}
-          LIVRE {{amount} livre}
-          OUNCE {{amount} oz}
-          POUND {{amount} lb}
-          BAR {{amount} Bar}
-          PASCAL {{amount} Pa}
-          HECTOPASCAL {{amount} hPa}
-          MILLIBAR {{amount} mBar}
-          ATM {{amount} atm}
-          PSI {{amount} PSI}
-          TORR {{amount} Torr}
-          MMHG {{amount} mmHg}
-          JOULE {{amount} J}
-          CALORIE {{amount} cal}
-          KILOCALORIE {{amount} kcal}
-          KILOJOULE {{amount} kJ}
-          PIECE {{amount} Pc}
-          DOZEN {{amount} Dz}
-          LUMEN {{amount} lm}
-          NIT {{amount} nits}
-          other  {{amount} {unit}}
+          SQUARE_MILLIMETER {{amount, number} mm²}
+          SQUARE_CENTIMETER {{amount, number} cm²}
+          SQUARE_DECIMETER {{amount, number} dm²}
+          SQUARE_METER {{amount, number} m²}
+          CENTIARE {{amount, number} ca}
+          SQUARE_DEKAMETER {{amount, number} dam²}
+          SQUARE_MILLIMETER {{amount, number} mm²}
+          ARE {{amount, number} a}
+          SQUARE_HECTOMETER {{amount, number} hm²}
+          HECTARE {{amount, number} ha}
+          SQUARE_KILOMETER {{amount, number} km²}
+          SQUARE_MIL {{amount, number} sq mil}
+          SQUARE_INCH {{amount, number} in²}
+          SQUARE_FOOT {{amount, number} ft²}
+          SQUARE_YARD {{amount, number} yd²}
+          ARPENT {{amount, number} arpent}
+          ACRE {{amount, number} a}
+          SQUARE_FURLONG {{amount, number} fur²}
+          SQUARE_MILE {{amount, number} mi²}
+          BIT {{amount, number} b}
+          BYTE {{amount, number} B}
+          KILOBYTE {{amount, number} kB}
+          MEGABYTE {{amount, number} MB}
+          GIGABYTE {{amount, number} GB}
+          TERABYTE {{amount, number} TB}
+          DECIBEL {{amount, number} dB}
+          HERTZ {{amount, number} Hz}
+          KILOHERTZ {{amount, number} kHz}
+          MEGAHERTZ {{amount, number} MHz}
+          GIGAHERTZ {{amount, number} GHz}
+          TERAHERTZ {{amount, number} THz}
+          MILLIMETER {{amount, number} mm}
+          CENTIMETER {{amount, number} cm}
+          DECIMETER {{amount, number} dm}
+          METER {{amount, number} m}
+          DEKAMETER {{amount, number} dam}
+          HECTOMETER {{amount, number} hm}
+          KILOMETER {{amount, number} km}
+          MIL {{amount, number} mil}
+          INCH {{amount, number} in}
+          FEET {{amount, number} ft}
+          YARD {{amount, number} yd}
+          CHAIN {{amount, number} ch}
+          FURLONG {{amount, number} fur}
+          MILE {{amount, number} mi}
+          WATT {{amount, number} W}
+          KILOWATT {{amount, number} kW}
+          MEGAWATT {{amount, number} MW}
+          GIGAWATT {{amount, number} GW}
+          TERAWATT {{amount, number} TW}
+          MILLIVOLT {{amount, number} mV}
+          CENTIVOLT {{amount, number} cV}
+          DECIVOLT {{amount, number} dV}
+          VOLT {{amount, number} V}
+          DEKAVOLT {{amount, number} daV}
+          HECTOVOLT {{amount, number} hV}
+          KILOVOLT {{amount, number} kV}
+          MILLIAMPERE {{amount, number} mA}
+          CENTIAMPERE {{amount, number} cA}
+          DECIAMPERE {{amount, number} dA}
+          AMPERE {{amount, number} A}
+          DEKAMPERE {{amount, number} daA}
+          HECTOAMPERE {{amount, number} hA}
+          KILOAMPERE {{amount, number} kA}
+          MILLIOHM {{amount, number} mΩ}
+          CENTIOHM {{amount, number} cΩ}
+          DECIOHM {{amount, number} dΩ}
+          OHM {{amount, number} Ω}
+          DEKAOHM {{amount, number} daΩ}
+          HECTOHM {{amount, number} hΩ}
+          KILOHM {{amount, number} kΩ}
+          MEGOHM {{amount, number} MΩ}
+          METER_PER_SECOND {{amount, number} m/s}
+          METER_PER_MINUTE {{amount, number} m/mn}
+          METER_PER_HOUR {{amount, number} m/h}
+          KILOMETER_PER_HOUR {{amount, number} km/h}
+          FOOT_PER_SECOND {{amount, number} ft/s}
+          FOOT_PER_HOUR {{amount, number} ft/h}
+          YARD_PER_HOUR {{amount, number} yd/h}
+          MILE_PER_HOUR {{amount, number} mi/h}
+          MILLIAMPEREHOUR {{amount, number} mAh}
+          AMPEREHOUR {{amount, number} Ah}
+          MILLICOULOMB {{amount, number} mC}
+          CENTICOULOMB {{amount, number} cC}
+          DECICOULOMB {{amount, number} dC}
+          COULOMB {{amount, number} C}
+          DEKACOULOMB {{amount, number} daC}
+          HECTOCOULOMB {{amount, number} hC}
+          KILOCOULOMB {{amount, number} kC}
+          MILLISECOND {{amount, number} ms}
+          SECOND {{amount, number} s}
+          MINUTE {{amount, number} m}
+          HOUR {{amount, number} h}
+          DAY {{amount, number} d}
+          WEEK {{amount, number} week}
+          MONTH {{amount, number} month}
+          YEAR {{amount, number} year}
+          CELSIUS {{amount, number}°C}
+          FAHRENHEIT {{amount, number}°F}
+          KELVIN {{amount, number}°K}
+          RANKINE {{amount, number}°R}
+          REAUMUR {{amount, number}°r}
+          CUBIC_MILLIMETER {{amount, number} mm³}
+          CUBIC_CENTIMETER {{amount, number} cm³}
+          MILLILITER {{amount, number} ml}
+          CENTILITER {{amount, number} cl}
+          DECILITER {{amount, number} dl}
+          CUBIC_DECIMETER {{amount, number} dm³}
+          LITER {{amount, number} l}
+          CUBIC_METER {{amount, number} m³}
+          OUNCE {{amount, number} oz}
+          PINT {{amount, number} pt}
+          BARREL {{amount, number} bbl}
+          GALLON {{amount, number} gal}
+          CUBIC_FOOT {{amount, number} ft³}
+          CUBIC_INCH {{amount, number} in³}
+          CUBIC_YARD {{amount, number} yd³}
+          MILLIGRAM {{amount, number} mg}
+          GRAM {{amount, number} g}
+          KILOGRAM {{amount, number} kg}
+          TON {{amount, number} t}
+          GRAIN {{amount, number} gr}
+          DENIER {{amount, number} denier}
+          ONCE {{amount, number} once}
+          MARC {{amount, number} marc}
+          LIVRE {{amount, number} livre}
+          OUNCE {{amount, number} oz}
+          POUND {{amount, number} lb}
+          BAR {{amount, number} Bar}
+          PASCAL {{amount, number} Pa}
+          HECTOPASCAL {{amount, number} hPa}
+          MILLIBAR {{amount, number} mBar}
+          ATM {{amount, number} atm}
+          PSI {{amount, number} PSI}
+          TORR {{amount, number} Torr}
+          MMHG {{amount, number} mmHg}
+          JOULE {{amount, number} J}
+          CALORIE {{amount, number} cal}
+          KILOCALORIE {{amount, number} kcal}
+          KILOJOULE {{amount, number} kJ}
+          PIECE {{amount, number} Pc}
+          DOZEN {{amount, number} Dz}
+          LUMEN {{amount, number} lm}
+          NIT {{amount, number} nits}
+          other  {{amount, number} {unit}}
       }

--- a/src/Resources/translations/messages+intl-icu.it.yaml
+++ b/src/Resources/translations/messages+intl-icu.it.yaml
@@ -2,149 +2,149 @@ webgriffe_sylius_akeneo:
   ui:
     metric_amount_unit: >-
       {unit, select,
-          SQUARE_MILLIMETER {{amount} mm²}
-          SQUARE_CENTIMETER {{amount} cm²}
-          SQUARE_DECIMETER {{amount} dm²}
-          SQUARE_METER {{amount} m²}
-          CENTIARE {{amount} ca}
-          SQUARE_DEKAMETER {{amount} dam²}
-          SQUARE_MILLIMETER {{amount} mm²}
-          ARE {{amount} a}
-          SQUARE_HECTOMETER {{amount} hm²}
-          HECTARE {{amount} ha}
-          SQUARE_KILOMETER {{amount} km²}
-          SQUARE_MIL {{amount} sq mil}
-          SQUARE_INCH {{amount} in²}
-          SQUARE_FOOT {{amount} ft²}
-          SQUARE_YARD {{amount} yd²}
-          ARPENT {{amount} arpent}
-          ACRE {{amount} a}
-          SQUARE_FURLONG {{amount} fur²}
-          SQUARE_MILE {{amount} mi²}
-          BIT {{amount} b}
-          BYTE {{amount} B}
-          KILOBYTE {{amount} kB}
-          MEGABYTE {{amount} MB}
-          GIGABYTE {{amount} GB}
-          TERABYTE {{amount} TB}
-          DECIBEL {{amount} dB}
-          HERTZ {{amount} Hz}
-          KILOHERTZ {{amount} kHz}
-          MEGAHERTZ {{amount} MHz}
-          GIGAHERTZ {{amount} GHz}
-          TERAHERTZ {{amount} THz}
-          MILLIMETER {{amount} mm}
-          CENTIMETER {{amount} cm}
-          DECIMETER {{amount} dm}
-          METER {{amount} m}
-          DEKAMETER {{amount} dam}
-          HECTOMETER {{amount} hm}
-          KILOMETER {{amount} km}
-          MIL {{amount} mil}
-          INCH {{amount} in}
-          FEET {{amount} ft}
-          YARD {{amount} yd}
-          CHAIN {{amount} ch}
-          FURLONG {{amount} fur}
-          MILE {{amount} mi}
-          WATT {{amount} W}
-          KILOWATT {{amount} kW}
-          MEGAWATT {{amount} MW}
-          GIGAWATT {{amount} GW}
-          TERAWATT {{amount} TW}
-          MILLIVOLT {{amount} mV}
-          CENTIVOLT {{amount} cV}
-          DECIVOLT {{amount} dV}
-          VOLT {{amount} V}
-          DEKAVOLT {{amount} daV}
-          HECTOVOLT {{amount} hV}
-          KILOVOLT {{amount} kV}
-          MILLIAMPERE {{amount} mA}
-          CENTIAMPERE {{amount} cA}
-          DECIAMPERE {{amount} dA}
-          AMPERE {{amount} A}
-          DEKAMPERE {{amount} daA}
-          HECTOAMPERE {{amount} hA}
-          KILOAMPERE {{amount} kA}
-          MILLIOHM {{amount} mΩ}
-          CENTIOHM {{amount} cΩ}
-          DECIOHM {{amount} dΩ}
-          OHM {{amount} Ω}
-          DEKAOHM {{amount} daΩ}
-          HECTOHM {{amount} hΩ}
-          KILOHM {{amount} kΩ}
-          MEGOHM {{amount} MΩ}
-          METER_PER_SECOND {{amount} m/s}
-          METER_PER_MINUTE {{amount} m/mn}
-          METER_PER_HOUR {{amount} m/h}
-          KILOMETER_PER_HOUR {{amount} km/h}
-          FOOT_PER_SECOND {{amount} ft/s}
-          FOOT_PER_HOUR {{amount} ft/h}
-          YARD_PER_HOUR {{amount} yd/h}
-          MILE_PER_HOUR {{amount} mi/h}
-          MILLIAMPEREHOUR {{amount} mAh}
-          AMPEREHOUR {{amount} Ah}
-          MILLICOULOMB {{amount} mC}
-          CENTICOULOMB {{amount} cC}
-          DECICOULOMB {{amount} dC}
-          COULOMB {{amount} C}
-          DEKACOULOMB {{amount} daC}
-          HECTOCOULOMB {{amount} hC}
-          KILOCOULOMB {{amount} kC}
-          MILLISECOND {{amount} ms}
-          SECOND {{amount} s}
-          MINUTE {{amount} m}
-          HOUR {{amount} h}
-          DAY {{amount} d}
-          WEEK {{amount} week}
-          MONTH {{amount} month}
-          YEAR {{amount} year}
-          CELSIUS {{amount}°C}
-          FAHRENHEIT {{amount}°F}
-          KELVIN {{amount}°K}
-          RANKINE {{amount}°R}
-          REAUMUR {{amount}°r}
-          CUBIC_MILLIMETER {{amount} mm³}
-          CUBIC_CENTIMETER {{amount} cm³}
-          MILLILITER {{amount} ml}
-          CENTILITER {{amount} cl}
-          DECILITER {{amount} dl}
-          CUBIC_DECIMETER {{amount} dm³}
-          LITER {{amount} l}
-          CUBIC_METER {{amount} m³}
-          OUNCE {{amount} oz}
-          PINT {{amount} pt}
-          BARREL {{amount} bbl}
-          GALLON {{amount} gal}
-          CUBIC_FOOT {{amount} ft³}
-          CUBIC_INCH {{amount} in³}
-          CUBIC_YARD {{amount} yd³}
-          MILLIGRAM {{amount} mg}
-          GRAM {{amount} g}
-          KILOGRAM {{amount} kg}
-          TON {{amount} t}
-          GRAIN {{amount} gr}
-          DENIER {{amount} denier}
-          ONCE {{amount} once}
-          MARC {{amount} marc}
-          LIVRE {{amount} livre}
-          OUNCE {{amount} oz}
-          POUND {{amount} lb}
-          BAR {{amount} Bar}
-          PASCAL {{amount} Pa}
-          HECTOPASCAL {{amount} hPa}
-          MILLIBAR {{amount} mBar}
-          ATM {{amount} atm}
-          PSI {{amount} PSI}
-          TORR {{amount} Torr}
-          MMHG {{amount} mmHg}
-          JOULE {{amount} J}
-          CALORIE {{amount} cal}
-          KILOCALORIE {{amount} kcal}
-          KILOJOULE {{amount} kJ}
-          PIECE {{amount} Pc}
-          DOZEN {{amount} Dz}
-          LUMEN {{amount} lm}
-          NIT {{amount} nits}
-          other  {{amount} {unit}}
+          SQUARE_MILLIMETER {{amount, number} mm²}
+          SQUARE_CENTIMETER {{amount, number} cm²}
+          SQUARE_DECIMETER {{amount, number} dm²}
+          SQUARE_METER {{amount, number} m²}
+          CENTIARE {{amount, number} ca}
+          SQUARE_DEKAMETER {{amount, number} dam²}
+          SQUARE_MILLIMETER {{amount, number} mm²}
+          ARE {{amount, number} a}
+          SQUARE_HECTOMETER {{amount, number} hm²}
+          HECTARE {{amount, number} ha}
+          SQUARE_KILOMETER {{amount, number} km²}
+          SQUARE_MIL {{amount, number} sq mil}
+          SQUARE_INCH {{amount, number} in²}
+          SQUARE_FOOT {{amount, number} ft²}
+          SQUARE_YARD {{amount, number} yd²}
+          ARPENT {{amount, number} arpent}
+          ACRE {{amount, number} a}
+          SQUARE_FURLONG {{amount, number} fur²}
+          SQUARE_MILE {{amount, number} mi²}
+          BIT {{amount, number} b}
+          BYTE {{amount, number} B}
+          KILOBYTE {{amount, number} kB}
+          MEGABYTE {{amount, number} MB}
+          GIGABYTE {{amount, number} GB}
+          TERABYTE {{amount, number} TB}
+          DECIBEL {{amount, number} dB}
+          HERTZ {{amount, number} Hz}
+          KILOHERTZ {{amount, number} kHz}
+          MEGAHERTZ {{amount, number} MHz}
+          GIGAHERTZ {{amount, number} GHz}
+          TERAHERTZ {{amount, number} THz}
+          MILLIMETER {{amount, number} mm}
+          CENTIMETER {{amount, number} cm}
+          DECIMETER {{amount, number} dm}
+          METER {{amount, number} m}
+          DEKAMETER {{amount, number} dam}
+          HECTOMETER {{amount, number} hm}
+          KILOMETER {{amount, number} km}
+          MIL {{amount, number} mil}
+          INCH {{amount, number} in}
+          FEET {{amount, number} ft}
+          YARD {{amount, number} yd}
+          CHAIN {{amount, number} ch}
+          FURLONG {{amount, number} fur}
+          MILE {{amount, number} mi}
+          WATT {{amount, number} W}
+          KILOWATT {{amount, number} kW}
+          MEGAWATT {{amount, number} MW}
+          GIGAWATT {{amount, number} GW}
+          TERAWATT {{amount, number} TW}
+          MILLIVOLT {{amount, number} mV}
+          CENTIVOLT {{amount, number} cV}
+          DECIVOLT {{amount, number} dV}
+          VOLT {{amount, number} V}
+          DEKAVOLT {{amount, number} daV}
+          HECTOVOLT {{amount, number} hV}
+          KILOVOLT {{amount, number} kV}
+          MILLIAMPERE {{amount, number} mA}
+          CENTIAMPERE {{amount, number} cA}
+          DECIAMPERE {{amount, number} dA}
+          AMPERE {{amount, number} A}
+          DEKAMPERE {{amount, number} daA}
+          HECTOAMPERE {{amount, number} hA}
+          KILOAMPERE {{amount, number} kA}
+          MILLIOHM {{amount, number} mΩ}
+          CENTIOHM {{amount, number} cΩ}
+          DECIOHM {{amount, number} dΩ}
+          OHM {{amount, number} Ω}
+          DEKAOHM {{amount, number} daΩ}
+          HECTOHM {{amount, number} hΩ}
+          KILOHM {{amount, number} kΩ}
+          MEGOHM {{amount, number} MΩ}
+          METER_PER_SECOND {{amount, number} m/s}
+          METER_PER_MINUTE {{amount, number} m/mn}
+          METER_PER_HOUR {{amount, number} m/h}
+          KILOMETER_PER_HOUR {{amount, number} km/h}
+          FOOT_PER_SECOND {{amount, number} ft/s}
+          FOOT_PER_HOUR {{amount, number} ft/h}
+          YARD_PER_HOUR {{amount, number} yd/h}
+          MILE_PER_HOUR {{amount, number} mi/h}
+          MILLIAMPEREHOUR {{amount, number} mAh}
+          AMPEREHOUR {{amount, number} Ah}
+          MILLICOULOMB {{amount, number} mC}
+          CENTICOULOMB {{amount, number} cC}
+          DECICOULOMB {{amount, number} dC}
+          COULOMB {{amount, number} C}
+          DEKACOULOMB {{amount, number} daC}
+          HECTOCOULOMB {{amount, number} hC}
+          KILOCOULOMB {{amount, number} kC}
+          MILLISECOND {{amount, number} ms}
+          SECOND {{amount, number} s}
+          MINUTE {{amount, number} m}
+          HOUR {{amount, number} h}
+          DAY {{amount, number} d}
+          WEEK {{amount, number} week}
+          MONTH {{amount, number} month}
+          YEAR {{amount, number} year}
+          CELSIUS {{amount, number}°C}
+          FAHRENHEIT {{amount, number}°F}
+          KELVIN {{amount, number}°K}
+          RANKINE {{amount, number}°R}
+          REAUMUR {{amount, number}°r}
+          CUBIC_MILLIMETER {{amount, number} mm³}
+          CUBIC_CENTIMETER {{amount, number} cm³}
+          MILLILITER {{amount, number} ml}
+          CENTILITER {{amount, number} cl}
+          DECILITER {{amount, number} dl}
+          CUBIC_DECIMETER {{amount, number} dm³}
+          LITER {{amount, number} l}
+          CUBIC_METER {{amount, number} m³}
+          OUNCE {{amount, number} oz}
+          PINT {{amount, number} pt}
+          BARREL {{amount, number} bbl}
+          GALLON {{amount, number} gal}
+          CUBIC_FOOT {{amount, number} ft³}
+          CUBIC_INCH {{amount, number} in³}
+          CUBIC_YARD {{amount, number} yd³}
+          MILLIGRAM {{amount, number} mg}
+          GRAM {{amount, number} g}
+          KILOGRAM {{amount, number} kg}
+          TON {{amount, number} t}
+          GRAIN {{amount, number} gr}
+          DENIER {{amount, number} denier}
+          ONCE {{amount, number} once}
+          MARC {{amount, number} marc}
+          LIVRE {{amount, number} livre}
+          OUNCE {{amount, number} oz}
+          POUND {{amount, number} lb}
+          BAR {{amount, number} Bar}
+          PASCAL {{amount, number} Pa}
+          HECTOPASCAL {{amount, number} hPa}
+          MILLIBAR {{amount, number} mBar}
+          ATM {{amount, number} atm}
+          PSI {{amount, number} PSI}
+          TORR {{amount, number} Torr}
+          MMHG {{amount, number} mmHg}
+          JOULE {{amount, number} J}
+          CALORIE {{amount, number} cal}
+          KILOCALORIE {{amount, number} kcal}
+          KILOJOULE {{amount, number} kJ}
+          PIECE {{amount, number} Pc}
+          DOZEN {{amount, number} Dz}
+          LUMEN {{amount, number} lm}
+          NIT {{amount, number} nits}
+          other  {{amount, number} {unit}}
       }

--- a/tests/Integration/Converter/ValueConverterTest.php
+++ b/tests/Integration/Converter/ValueConverterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Webgriffe\SyliusAkeneoPlugin\Integration\Converter;
+
+use Sylius\Component\Product\Model\ProductAttribute;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Webgriffe\SyliusAkeneoPlugin\Converter\ValueConverterInterface;
+
+class ValueConverterTest extends KernelTestCase
+{
+    private ValueConverterInterface $valueConverter;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->valueConverter = self::getContainer()->get('webgriffe_sylius_akeneo.converter.value');
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_metric_value_mantaining_significant_decimal(): void
+    {
+        $attribute = new ProductAttribute();
+        $valueConverted = $this->valueConverter->convert($attribute, [
+            'amount' => 23.045000,
+            'unit' => 'INCH',
+        ], 'it');
+
+        self::assertEquals('23,045 in', $valueConverted);
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_metric_value_removing_not_significant_decimal(): void
+    {
+        $attribute = new ProductAttribute();
+        $valueConverted = $this->valueConverter->convert($attribute, [
+            'amount' => 54.0000,
+            'unit' => 'METER',
+        ], 'en');
+
+        self::assertEquals('54 m', $valueConverted);
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_metric_value_with_amount_zero_if_it_is_empty(): void
+    {
+        $attribute = new ProductAttribute();
+        $valueConverted = $this->valueConverter->convert($attribute, [
+            'amount' => null,
+            'unit' => 'METER',
+        ], 'en');
+
+        self::assertEquals('0 m', $valueConverted);
+    }
+}

--- a/tests/Integration/Converter/ValueConverterTest.php
+++ b/tests/Integration/Converter/ValueConverterTest.php
@@ -13,7 +13,7 @@ class ValueConverterTest extends KernelTestCase
     protected function setUp(): void
     {
         self::bootKernel();
-        $this->valueConverter = self::getContainer()->get('webgriffe_sylius_akeneo.converter.value');
+        $this->valueConverter = self::$container->get('webgriffe_sylius_akeneo.converter.value');
     }
 
     /**


### PR DESCRIPTION
The problem is that the Akeneo API returns for metrical values an amount formatted with 4 decimals (ex: 3.3221, 43.1200, and 4.0000). The text attribute value will become like "3.3221 m" or "4.0000 m". This is not very "graceful" to see as well as confusing.