### PR TITLE
Fix psalm errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,13 @@
         "vimeo/psalm": "4.7.1"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true,
+            "composer/package-versions-deprecated": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "symfony/thanks": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,3 +14,7 @@ parameters:
         - '/Parameter #1 \$configuration of method Symfony\\Component\\DependencyInjection\\Extension\\Extension::processConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\ConfigurationInterface, Symfony\\Component\\Config\\Definition\\ConfigurationInterface\|null given\./'
         - '/Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\./'
         - '/Parameter \#1 \$event of method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) expects object, string given\./'
+        -
+            message: '/Cannot call method trans\(\) on Symfony\\Contracts\\Translation\\TranslatorInterface\|null\./'
+            path: src/Controller/ProductEnqueueController
+

--- a/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
+++ b/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
@@ -300,6 +300,7 @@ final class WebgriffeSyliusAkeneoExtension extends AbstractResourceExtension imp
 
         $taggedReconcilers = $container->findTaggedServiceIds(self::RECONCILER_TAG);
         foreach ($taggedReconcilers as $id => $_tags) {
+            /** @psalm-suppress MixedArgumentTypeCoercion */
             $importerRegistryDefinition->addMethodCall('add', [new Reference($id)]);
         }
     }

--- a/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
+++ b/src/DependencyInjection/WebgriffeSyliusAkeneoExtension.php
@@ -298,7 +298,6 @@ final class WebgriffeSyliusAkeneoExtension extends AbstractResourceExtension imp
 
         $importerRegistryDefinition = $container->findDefinition('webgriffe_sylius_akeneo.reconciler_registry');
 
-        /** @var array<string, array> $taggedReconcilers */
         $taggedReconcilers = $container->findTaggedServiceIds(self::RECONCILER_TAG);
         foreach ($taggedReconcilers as $id => $_tags) {
             $importerRegistryDefinition->addMethodCall('add', [new Reference($id)]);


### PR DESCRIPTION
These changes will solve psalm errors in test action. One is due to the deprecation of method get inside a Controller which extends the AbstractController from Symfony. The new suggested method is to manually pass the service from the constructor of the class. So, to avoid a BC break, a new deprecation has been added.