### PR TITLE
Use Akeneo value if label is not defined for a locale

### DIFF
--- a/src/ValueHandler/ProductOptionValueHandler.php
+++ b/src/ValueHandler/ProductOptionValueHandler.php
@@ -189,6 +189,10 @@ final class ProductOptionValueHandler implements ValueHandlerInterface
                 )
             );
         }
+        /**
+         * @var string $localeCode
+         * @var ?string $label
+         */
         foreach ($akeneoAttributeOption['labels'] as $localeCode => $label) {
             if ($this->translationLocaleProvider !== null &&
                 !in_array($localeCode, $this->translationLocaleProvider->getDefinedLocalesCodes(), true)) {
@@ -200,7 +204,7 @@ final class ProductOptionValueHandler implements ValueHandlerInterface
                 $optionValueTranslation = $this->productOptionValueTranslationFactory->createNew();
                 $optionValueTranslation->setLocale($localeCode);
             }
-            $optionValueTranslation->setValue($label);
+            $optionValueTranslation->setValue($label ?? $akeneoValue);
             if (!$optionValue->hasTranslation($optionValueTranslation)) {
                 $optionValue->addTranslation($optionValueTranslation);
             }


### PR DESCRIPTION
Changes proposed in this pull request:
- Use Akeneo value if label is not defined for a locale in product option value handler

@webgriffe/wg-devs what do you think about this PR :shipit:?

<!--
 - Bug fixes must be submitted against the 1.13 branch(the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
