### PR TITLE
Use rawurlencode

### DIFF
--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -343,6 +343,6 @@ final class ApiClient implements ApiClientInterface, AttributeOptionsApiClientIn
 
     private function getEncodedProductCode(string $code): string
     {
-        return implode('/', array_map('urlencode', explode('/', $code)));
+        return implode('/', array_map('rawurlencode', explode('/', $code)));
     }
 }


### PR DESCRIPTION
We must use "rawurlencode" instead "urlencode" as stated [here](https://stackoverflow.com/a/2678602)
Otherwise, if you have a product with whitespaces in its code, the plugin will try to fetch the product from Akeneo with this URL
`https://mtdistribuzione-pim-live.webgriffe.systems/api/rest/v1/products/AWC_AP64+BUS`
that will generate a 404, 'cause the correct URL is:
`https://mtdistribuzione-pim-live.webgriffe.systems/api/rest/v1/products/AWC_AP64%20BUS`

Even the official API client [uses the rawurlencode](https://github.com/akeneo/api-php-client/blob/0d9c9f80baf9ae190c01133e239913de00138217/src/Routing/UriGenerator.php#L80)