### PR TITLE
Move conflicts to composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,16 +39,17 @@
         "phpstan/phpstan-strict-rules": "^0.12.0",
         "phpstan/phpstan-webmozart-assert": "0.12.12",
         "phpunit/phpunit": "^9.5",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "sensiolabs/security-checker": "^6.0",
-        "sylius-labs/coding-standard": "^4.0",
+        "sylius-labs/coding-standard": "<=4.2.0",
         "symfony/browser-kit": "^4.4 || ^5.2",
         "symfony/debug-bundle": "^4.4 || ^5.2",
         "symfony/dotenv": "^4.4 || ^5.2",
         "symfony/intl": "^4.4 || ^5.2",
         "symfony/web-profiler-bundle": "^4.4 || ^5.2",
+        "symplify/easy-coding-standard": "^9.0",
         "theofidry/alice-data-fixtures": "^1.1",
-        "vimeo/psalm": "4.23.0",
-        "polishsymfonycommunity/symfony-mocker-container": "^1.0"
+        "vimeo/psalm": "4.23.0"
     },
     "config": {
         "sort-packages": true,
@@ -58,10 +59,6 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "symfony/thanks": true
         }
-    },
-    "conflict": {
-        "sylius-labs/coding-standard": ">=4.2.1",
-        "symplify/easy-coding-standard": "^10"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Sadly, the "conflicts" composer config is checked even for dev requirements, so if you try to update the plugin to version 1.15.2 it could conflict due to easy coding standards and sylius-lab dependencies, even thought they are dev dependencies.
I moved them as composer dev requirements.