### PR TITLE
Avoid database error while creating products without name (#148)

### DIFF
--- a/features/importing_products_from_queue.feature
+++ b/features/importing_products_from_queue.feature
@@ -45,3 +45,15 @@ Feature: Importing products from queue
     And there is one item to import with identifier "braided-hat-l" for the "Product" importer in the Akeneo queue
     When I import all items in queue
     Then there should not be any temporary file in the temporary files directory
+
+  @cli
+  Scenario: Preventing database inconsistency errors that will block product imports
+    Given the store operates on a single channel
+    And the store is also available in "it_IT"
+    And there is one item to import with identifier "empty-name-product" for the "Product" importer in the Akeneo queue
+    And there is one item to import with identifier "braided-hat-m" for the "Product" importer in the Akeneo queue
+    When I import all items in queue
+    Then the product "empty-name-product" should not exists
+    And the product variant "braided-hat-m" of product "model-braided-hat" should exists with the right data
+    And the queue item with identifier "empty-name-product" for the "Product" importer has not been marked as imported
+    And the queue item with identifier "braided-hat-m" for the "Product" importer has been marked as imported

--- a/src/Product/Exception/ProductTranslationNameNullException.php
+++ b/src/Product/Exception/ProductTranslationNameNullException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webgriffe\SyliusAkeneoPlugin\Product\Exception;
+
+use RuntimeException;
+
+final class ProductTranslationNameNullException extends RuntimeException
+{
+}

--- a/src/Product/Exception/ProductTranslationSlugNullException.php
+++ b/src/Product/Exception/ProductTranslationSlugNullException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webgriffe\SyliusAkeneoPlugin\Product\Exception;
+
+use RuntimeException;
+
+final class ProductTranslationSlugNullException extends RuntimeException
+{
+}

--- a/tests/Integration/DataFixtures/ApiClientMock/Product/empty-name-product.json
+++ b/tests/Integration/DataFixtures/ApiClientMock/Product/empty-name-product.json
@@ -1,5 +1,5 @@
 {
-    "identifier": "no-name-product",
+    "identifier": "empty-name-product",
     "enabled": true,
     "family": "pc_monitors",
     "categories": [
@@ -10,6 +10,13 @@
     "groups": [],
     "parent": null,
     "values": {
+        "name": [
+            {
+                "locale": "it_IT",
+                "scope": null,
+                "data": ""
+            }
+        ],
         "price": [
             {
                 "locale": null,
@@ -26,14 +33,14 @@
             {
                 "locale": null,
                 "scope": null,
-                "data": "no-name-product"
+                "data": "empty-name-product"
             }
         ],
         "description": [
             {
                 "locale": null,
                 "scope": null,
-                "data": "No name product"
+                "data": "Empty name product"
             }
         ]
     },


### PR DESCRIPTION
Fixes #148 

Changes proposed in this pull request:
- Check for product and product variant integrity before trying to persist them on DB
